### PR TITLE
Enable jupyter-book=0.14 + sphinx book theme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       # - name: Build PDF from LaTeX
       #   shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Build HTML
         shell: bash -l {0}
         run: |
-          rm -r _build/.doctrees
+          # rm -r _build/.doctrees
           jb build lectures --path-output ./ -W --keep-going
       - name: Upload Execution Reports (HTML)
         uses: actions/upload-artifact@v2

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,9 @@ dependencies:
   - anaconda=2022.10
   - pip
   - pip:
-    - jupyter-book==0.13.2
-    - quantecon-book-theme==0.3.2
-    - sphinx-tojupyter==0.2.1
+    - jupyter-book==0.14.0
+    # - quantecon-book-theme==0.3.2
+    # - sphinx-tojupyter==0.2.1
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1
     - sphinx-proof==0.1.3

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -36,7 +36,7 @@ sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_exercise, sphinx_togglebutton, sphinx_proof] # sphinx_tojupyter
   config:
     html_favicon: _static/lectures-favicon.ico
-    html_theme: quantecon_book_theme
+    html_theme: sphinx_book_theme
     html_static_path: ['_static']
     html_theme_options:
       header_organisation_url: https://quantecon.org

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -39,15 +39,15 @@ sphinx:
     html_theme: sphinx_book_theme
     html_static_path: ['_static']
     html_theme_options:
-      header_organisation_url: https://quantecon.org
-      header_organisation: QuantEcon
+      # header_organisation_url: https://quantecon.org
+      # header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-python-intro
-      nb_repository_url: https://github.com/QuantEcon/lecture-python-intro.notebooks
-      twitter: quantecon
-      twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
-      og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
-      description: This website presents a set of lectures on python programming for economics, designed and written by Thomas J. Sargent and John Stachurski.
-      keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
+      # nb_repository_url: https://github.com/QuantEcon/lecture-python-intro.notebooks
+      # twitter: quantecon
+      # twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
+      # og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
+      # description: This website presents a set of lectures on python programming for economics, designed and written by Thomas J. Sargent and John Stachurski.
+      # keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
       # analytics:
       #   google_analytics_id: UA-54984338-9
       launch_buttons:

--- a/lectures/inequality.md
+++ b/lectures/inequality.md
@@ -506,6 +506,8 @@ plt.title("Gini coefficients of US income data")
 plt.show()
 ```
 
+**TEST ===>** Here is a {ref}`gini_us` and a {numref}`gini_us`
+
 We see that, by this measure, inequality in wealth and income has risen
 substantially since 1980.
 


### PR DESCRIPTION
This PR upgrades `jupyter-book` to the latest released version which brings lots of improvements. 

- [x] test out references to figures that are generated by code (`ref` and `numref` roles)