### PR TITLE
MAINT: Upgrade jupyter-book to 0.15.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - anaconda=2022.10
   - pip
   - pip:
-    - jupyter-book==0.14.0
+    - jupyter-book==0.15.1
     # - quantecon-book-theme==0.3.2
     # - sphinx-tojupyter==0.2.1
     - sphinxext-rediraffe==0.2.7


### PR DESCRIPTION
This PR just bumps jupyter-book another version to support latest theme.