### PR TITLE
MAINT: Maintenance for GitHub Actions + enable download notebooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,12 @@ jobs:
       #     jb build lectures --builder pdflatex --path-output ./ -n --keep-going
       #     mkdir -p _build/html/_pdf
       #     cp -u _build/latex/*.pdf _build/html/_pdf
-      # - name: Build Download Notebooks (sphinx-tojupyter)
-      #   shell: bash -l {0}
-      #   run: |
-      #     jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
-      #     mkdir -p _build/html/_notebooks
-      #     cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      - name: Build Download Notebooks (sphinx-tojupyter)
+        shell: bash -l {0}
+        run: |
+          jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
+          mkdir -p _build/html/_notebooks
+          cp -u _build/jupyter/*.ipynb _build/html/_notebooks
       # Build HTML (Website)
       # BUG: rm .doctress to remove `sphinx` rendering issues for ipywidget mimetypes
       # and clear the sphinx cache for building final HTML documents.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build HTML [using jupyter-book]
-on: [push]
+on: [pull-request]
 jobs:
-  tests:
+  preview:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Build HTML [using jupyter-book]
-on: [pull-request]
+on: [pull_request]
 jobs:
   preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,15 +55,15 @@ jobs:
       #   run: |
       #     mkdir -p _build/html/_pdf
       #     cp -u _build/latex/*.pdf _build/html/_pdf
-      # - name: Build Download Notebooks (sphinx-tojupyter)
-      #   shell: bash -l {0}
-      #   run: |
-      #     jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
-      # - name: Copy Download Notebooks for GH-PAGES
-      #   shell: bash -l {0}
-      #   run: |
-      #     mkdir -p _build/html/_notebooks
-      #     cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      - name: Build Download Notebooks (sphinx-tojupyter)
+        shell: bash -l {0}
+        run: |
+          jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
+      - name: Copy Download Notebooks for GH-PAGES
+        shell: bash -l {0}
+        run: |
+          mkdir -p _build/html/_notebooks
+          cp -u _build/jupyter/*.ipynb _build/html/_notebooks
       # Build HTML (Website)
       # BUG: rm .doctress to remove `sphinx` rendering issues for ipywidget mimetypes
       # and clear the sphinx cache for building final HTML documents.
@@ -93,21 +93,22 @@ jobs:
         with:
           name: build-publish
           path: _build
-      # - name: Prepare lecture-python-intro.notebooks sync
-      #   shell: bash -l {0}
-      #   run: |
-      #     mkdir -p _build/lecture-python-intro.notebooks
-      #     cp -a _notebook_repo/. _build/lecture-python-intro.notebooks
-      #     cp _build/jupyter/*.ipynb _build/lecture-python-intro.notebooks
-      #     ls -a _build/lecture-python-intro.notebooks
-      # - name: Commit latest notebooks to lecture-python-intro.notebooks
-      #   uses: cpina/github-action-push-to-another-repository@master
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.QUANTECON_SERVICES_PAT }}
-      #   with:
-      #     source-directory: '_build/lecture-python-intro.notebooks/'
-      #     destination-repository-username: 'QuantEcon'
-      #     destination-repository-name: 'lecture-python-intro.notebooks'
-      #     commit-message: 'auto publishing updates to notebooks'
-      #     destination-github-username: 'quantecon-services'
-      #     user-email: services@quantecon.org
+      # Sync notebooks
+      - name: Prepare lecture-python-intro.notebooks sync
+        shell: bash -l {0}
+        run: |
+          mkdir -p _build/lecture-python-intro.notebooks
+          cp -a _notebook_repo/. _build/lecture-python-intro.notebooks
+          cp _build/jupyter/*.ipynb _build/lecture-python-intro.notebooks
+          ls -a _build/lecture-python-intro.notebooks
+      - name: Commit latest notebooks to lecture-python-intro.notebooks
+        uses: cpina/github-action-push-to-another-repository@master
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.QUANTECON_SERVICES_PAT }}
+        with:
+          source-directory: '_build/lecture-python-intro.notebooks/'
+          destination-repository-username: 'QuantEcon'
+          destination-repository-name: 'lecture-python-intro.notebooks'
+          commit-message: 'auto publishing updates to notebooks'
+          destination-github-username: 'quantecon-services'
+          user-email: services@quantecon.org

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,11 +82,11 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      # - name: Deploy website to gh-pages
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: _build/html/
+      - name: Deploy website to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/html/
           # cname: intro.quantecon.org
       - name: Upload "_build" folder (cache)
         uses: actions/upload-artifact@v2

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -17,10 +17,12 @@ parse:
     - substitution
     - tasklist
 
+only_build_toc_files: true
 execute:
   execute_notebooks: "cache"
   timeout: 600 # 10 minutes
-#   run_in_temp: true
+  exclude_patterns:
+    - '_static/*'
 
 html:
   baseurl: https://intro.quantecon.org/
@@ -33,21 +35,21 @@ latex:
     targetname: quantecon-python-intro.tex
 
 sphinx:
-  extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_exercise, sphinx_togglebutton, sphinx_proof] # sphinx_tojupyter
+  extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_exercise, sphinx_togglebutton, sphinx_proof, sphinx_tojupyter] 
   config:
     html_favicon: _static/lectures-favicon.ico
     html_theme: quantecon_book_theme
     html_static_path: ['_static']
     html_theme_options:
-      # header_organisation_url: https://quantecon.org
-      # header_organisation: QuantEcon
+      header_organisation_url: https://quantecon.org
+      header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-python-intro
-      # nb_repository_url: https://github.com/QuantEcon/lecture-python-intro.notebooks
-      # twitter: quantecon
-      # twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
-      # og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
-      # description: This website presents a set of lectures on python programming for economics, designed and written by Thomas J. Sargent and John Stachurski.
-      # keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
+      nb_repository_url: https://github.com/QuantEcon/lecture-python-intro.notebooks
+      twitter: quantecon
+      twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
+      og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
+      description: This website presents introductory lectures on computational economics, designed and written by Thomas J. Sargent and John Stachurski.
+      keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
       # analytics:
       #   google_analytics_id: UA-54984338-9
       launch_buttons:


### PR DESCRIPTION
This PR is primarily a maintenance PR

- [x] docutils pin
- [x] enable `metadata` for `quantecon-book-theme`
- [x] enable download notebooks
- [x] setup lecture-python-intro.notebooks repo
- [x] setup `quantecon-services` as a maintainer
- [x] setup `ci` to push generated `ipynb` notebooks from `sphinx-tojupyter`
- [x] enable `GitHub pages` without `custom weblink`