### PR TITLE
FIX: Review mathjax

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -60,6 +60,6 @@ sphinx:
         binderhub_url             : https://mybinder.org  # The URL of the BinderHub (e.g., https://mybinder.org)
         colab_url                 : https://colab.research.google.com
         thebe                     : false  # Add a thebe button to pages (requires the repository to run on Binder)
-    mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+    # mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     rediraffe_redirects:
       index_toc.md: intro.md


### PR DESCRIPTION
# Do Not Merge

There is an issue with mathjax missing some math markup at the top of equations. 

Trying to replicate the issue of missing components from equations reported by @jstac. 

So far this seems contained to `Firefox` but will investigate compatibility.
