### PR TITLE
FIX: fix download noteboks with code-cell outputs

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -63,3 +63,16 @@ sphinx:
     mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     rediraffe_redirects:
       index_toc.md: intro.md
+    tojupyter_static_file_path: ["_static"]
+    tojupyter_target_html: true
+    tojupyter_urlpath: "https://intro.quantecon.org/"
+    tojupyter_image_urlpath: "https://intro.quantecon.org/_static/"
+    tojupyter_lang_synonyms: ["ipython", "ipython3", "python"]
+    tojupyter_kernels:
+      python3:
+        kernelspec:
+          display_name: "Python"
+          language: python3
+          name: python3
+        file_extension: ".py"
+    tojupyter_images_markdown: true


### PR DESCRIPTION
Current download notebook contain code highlighted cells when they should be `executable`

- [x] fix `tojupyter` config