### PR TITLE
MAINT: Test mybinder builds (to support binder option)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,8 @@ name: quantecon
 channels:
   - default
 dependencies:
-  - python=3.10
+  - python
   - anaconda=2023.03
-  - nbconvert=6.5.4
   - pip
   - pip:
     - jupyter-book==0.15.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: quantecon
 channels:
   - default
-  - conda-forge
 dependencies:
   - python=3.10
   - anaconda=2023.03

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.10
   - anaconda=2023.03
+  - nbconvert=6.5.4
   - pip
   - pip:
     - jupyter-book==0.15.1


### PR DESCRIPTION
The `mybinder` service is not working on the other lectures sites due to no capacity available + run out of disk space. 

I think we need to use colab for now at least

https://github.com/QuantEcon/quantecon-book-theme/issues/187