### PR TITLE
Fix Title Location of `lp_intro`

### DIFF
--- a/lectures/lp_intro.md
+++ b/lectures/lp_intro.md
@@ -10,6 +10,7 @@ kernelspec:
 ---
 
 (lp_intro)=
+# Linear Programming
 
 In this lecture, we will need the following library. Install [ortools](https://developers.google.com/optimization) using `pip`.
 
@@ -19,8 +20,6 @@ tags: [hide-output]
 ---
 !pip install ortools
 ```
-
-# Linear Programming
 
 ## Overview
 


### PR DESCRIPTION
This PR fixes the misplaced title in `lp_intro` lecture.