### PR TITLE
FIX: fix missing h0 returned from compute_optimal

### DIFF
--- a/lectures/cons_smooth.md
+++ b/lectures/cons_smooth.md
@@ -311,7 +311,7 @@ a0 = -2     # such as "student debt"
 y_seq = np.concatenate([np.ones(46), np.zeros(20)])
 
 cs_model = creat_cs_model()
-c_seq, a_seq = compute_optimal(cs_model, a0, y_seq)
+c_seq, a_seq, h0 = compute_optimal(cs_model, a0, y_seq)
 
 print('check a_T+1=0:', 
       np.abs(a_seq[-1] - 0) <= 1e-8)

--- a/lectures/cons_smooth.md
+++ b/lectures/cons_smooth.md
@@ -429,7 +429,7 @@ def compute_variation(model, ξ1, ϕ, a0, y_seq, verbose=1):
     if verbose == 1:
         print('check feasible:', np.isclose(β_seq @ v_seq, 0))     # since β = 1/R
 
-    c_opt, _ = compute_optimal(model, a0, y_seq)
+    c_opt, _, _ = compute_optimal(model, a0, y_seq)
     cvar_seq = c_opt + v_seq
 
     return cvar_seq


### PR DESCRIPTION
This PR collects `ho` now returned from `compute_optimal` from [194aef5](https://github.com/QuantEcon/lecture-python-intro/commit/194aef5f3d88d50334fd8a95ef2e42028f4707cc)