### PR TITLE
[complex_and_trig] Enforce `mathjax` output

### DIFF
--- a/lectures/complex_and_trig.md
+++ b/lectures/complex_and_trig.md
@@ -472,7 +472,7 @@ We can verify the analytical as well as numerical results using
 
 ```{code-cell} python3
 # Set initial printing
-init_printing()
+init_printing(use_latex="mathjax")
 
 ω = Symbol('ω')
 print('The analytical solution for integral of cos(ω)sin(ω) is:')


### PR DESCRIPTION
Hi @mmcky,

This PR resolves #351. 

For some reason, I have to enforce `mathjax` output in `init_printing` to get `sympy` printing in `latex`.

It should print in `latex` automatically if it detects `latex` in the environment.