### PR TITLE
MAINT: enable latex in the cache build environment for sympy rendering

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -18,6 +18,22 @@ jobs:
           python-version: "3.11"
           environment-file: environment.yml
           activate-environment: quantecon
+      - name: graphviz Support # TODO: required?
+        run: |
+          sudo apt-get -qq update && sudo apt-get install -y graphviz
+      - name: Install latex dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install -y     \
+            texlive-latex-recommended \
+            texlive-latex-extra       \
+            texlive-fonts-recommended \
+            texlive-fonts-extra       \
+            texlive-xetex             \
+            latexmk                   \
+            xindy                     \
+            dvipng                    \
+            cm-super
       - name: Build HTML
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
This PR should fix #351 by adding latex to the cache environment. 