### PR TITLE
ENH: update show code cell prompt to be more concise

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -34,6 +34,9 @@ latex:
   latex_documents:
     targetname: quantecon-python-intro.tex
 
+mystnb:
+  nb_code_prompt_show: "Show {type}"
+
 sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_exercise, sphinx_togglebutton, sphinx.ext.intersphinx, sphinx_proof, sphinx_tojupyter] 
   config:

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -34,9 +34,6 @@ latex:
   latex_documents:
     targetname: quantecon-python-intro.tex
 
-mystnb:
-  nb_code_prompt_show: "Show {type}"
-
 sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_exercise, sphinx_togglebutton, sphinx.ext.intersphinx, sphinx_proof, sphinx_tojupyter] 
   config:
@@ -45,6 +42,8 @@ sphinx:
     # myst-nb config
     nb_render_image_options:
       width: 80%
+    nb_code_prompt_show: "Show {type}"
+    # -------------
     html_favicon: _static/lectures-favicon.ico
     html_theme: quantecon_book_theme
     html_static_path: ['_static']


### PR DESCRIPTION
This PR uses `myst-nb` config to update the `Show code cell source` prompt to `Show source`

The `source` is backed into the `myst-nb` node so we could override through our own extension if needed