### PR TITLE
MAINT: add ignore for math.stackexchange and stackoverflow due to 403

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -38,7 +38,7 @@ sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_exercise, sphinx_togglebutton, sphinx.ext.intersphinx, sphinx_proof, sphinx_tojupyter] 
   config:
     # false-positive links
-    linkcheck_ignore: ['https://doi.org/https://doi.org/10.2307/1235116']
+    linkcheck_ignore: ['https://doi.org/https://doi.org/10.2307/1235116', 'https://math.stackexchange.com/*', 'https://stackoverflow.com/*']
     # myst-nb config
     nb_render_image_options:
       width: 80%


### PR DESCRIPTION
This PR enables ignore for these two domains as they are causing lots of false positives for the linkchecker due to 403 return code. 