### PR TITLE
Revert "MAINT: Upgrade anaconda and README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,42 @@
-# A First Course in Quantitative Economics with Python
+# lecture-python-intro
 
-An Undergraduate Lecture Series for the Foundations of Computational Economics
+An undergraduate lecture series for the foundations of computational economics
 
-## Jupyter notebooks
+## Content ideas 
 
-Jupyter notebook versions of each lecture are available for download
-via the website.
+Content ideas in no particular order.
 
-## Contributions
+Open individual issues and PRs for the ones we decide to add.
 
-To comment on the lectures please add to or open an issue in the issue tracker (see above).
+  1. Geometric Series (existing lecture)
+  2. Leontief Systems (from Networks Book)
+  3. Luenberger
+  4. IO Visualizations (from Networks Book)
+  5. PyPGM (Eileen Nielson ... Youtube Star)
+  6. Baby Version of https://python.quantecon.org/re_with_feedback.html (Cagan Model)
+  7. Baby Version of "unpleasant arithmetic and Friedmans optimal quantity of money"
+  8. Schelling Segregation Model
+  9. Solow Model
+  10. Simulations of Wealth Distribution
+  11. Baby model of Lake Model (Eigenvalue Extension)
+  12. Diamond Dybvig Model
+  13. Moral Harzard - Wallace
+  14. Philips Curve and Nairu
+  15. Baby version of the Markov Chain Lecture
+  16. Baby linear programming lecture
+  17. Basic Nonlinear Demand and Supply (non-linear solver) OOP lecture
+  18. Asset Pricing (Harrison/Kreps Model)
+  19. Two Models of Asset Bubbles
+  20. cobweb model -- start people thinking about expectations
+  21. social mobility lecture
+  22. Baby version of cattle cycles model
+  23. Bi-matrix games.
+  24. Shortest path lecture (existing)
+  25. Pricing an American option 
+  26. Baby version of LLN / CLT lecture --- less maths, more simulation, all in one dimension
+  27. Baby version of heavy tails lecture
+  30. Lecture on solving linear equations and matrix algebra
+  31. Lecture on eigenvalues, Perron-Frobenius and the Neumann series lemma
+  32. Overlapping generations
 
-We welcome pull requests!  
-
-Please read the [QuantEcon style guide](https://manual.quantecon.org/intro.html) first, so that you can match our style.
+Get Tom's network intermediary paper.

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - anaconda=2024.02
+  - anaconda=2023.09
   - pip
   - pip:
     - jupyter-book==0.15.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -37,7 +37,6 @@ latex:
 sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_exercise, sphinx_togglebutton, sphinx.ext.intersphinx, sphinx_proof, sphinx_tojupyter] 
   config:
-    bibtex_reference_style: author_year
     # false-positive links
     linkcheck_ignore: ['https://doi.org/https://doi.org/10.2307/1235116', 'https://math.stackexchange.com/*', 'https://stackoverflow.com/*']
     # myst-nb config

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -18,17 +18,6 @@ This table contains the latest execution statistics.
 
 (status:machine-details)=
 
-These lectures are built on `linux` instances through `github actions`. 
-
-These lectures are using the following python version
-
-```{code-cell} ipython
-!python --version
-```
-
-and the following package versions
-
-```{code-cell} ipython
-:tags: [hide-output]
-!conda list
-```
+These lectures are built on `linux` instances through `github actions`  and `amazon web services (aws)` to
+enable access to a `gpu`. These lectures are built on a [p3.2xlarge](https://aws.amazon.com/ec2/instance-types/p3/)
+that has access to `8 vcpu's`, a `V100 NVIDIA Tesla GPU`, and `61 Gb` of memory.


### PR DESCRIPTION
Reverts QuantEcon/lecture-python-intro#396

This upgrade requires updates to `interpolation`