### PR TITLE
MAINT: Upgrade anaconda and README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v2
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build PDF from LaTeX
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -1,42 +1,16 @@
-# lecture-python-intro
+# A First Course in Quantitative Economics with Python
 
-An undergraduate lecture series for the foundations of computational economics
+An Undergraduate Lecture Series for the Foundations of Computational Economics
 
-## Content ideas 
+## Jupyter notebooks
 
-Content ideas in no particular order.
+Jupyter notebook versions of each lecture are available for download
+via the website.
 
-Open individual issues and PRs for the ones we decide to add.
+## Contributions
 
-  1. Geometric Series (existing lecture)
-  2. Leontief Systems (from Networks Book)
-  3. Luenberger
-  4. IO Visualizations (from Networks Book)
-  5. PyPGM (Eileen Nielson ... Youtube Star)
-  6. Baby Version of https://python.quantecon.org/re_with_feedback.html (Cagan Model)
-  7. Baby Version of "unpleasant arithmetic and Friedmans optimal quantity of money"
-  8. Schelling Segregation Model
-  9. Solow Model
-  10. Simulations of Wealth Distribution
-  11. Baby model of Lake Model (Eigenvalue Extension)
-  12. Diamond Dybvig Model
-  13. Moral Harzard - Wallace
-  14. Philips Curve and Nairu
-  15. Baby version of the Markov Chain Lecture
-  16. Baby linear programming lecture
-  17. Basic Nonlinear Demand and Supply (non-linear solver) OOP lecture
-  18. Asset Pricing (Harrison/Kreps Model)
-  19. Two Models of Asset Bubbles
-  20. cobweb model -- start people thinking about expectations
-  21. social mobility lecture
-  22. Baby version of cattle cycles model
-  23. Bi-matrix games.
-  24. Shortest path lecture (existing)
-  25. Pricing an American option 
-  26. Baby version of LLN / CLT lecture --- less maths, more simulation, all in one dimension
-  27. Baby version of heavy tails lecture
-  30. Lecture on solving linear equations and matrix algebra
-  31. Lecture on eigenvalues, Perron-Frobenius and the Neumann series lemma
-  32. Overlapping generations
+To comment on the lectures please add to or open an issue in the issue tracker (see above).
 
-Get Tom's network intermediary paper.
+We welcome pull requests!  
+
+Please read the [QuantEcon style guide](https://manual.quantecon.org/intro.html) first, so that you can match our style.

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.11
-  - anaconda=2023.09
+  - anaconda=2024.02
   - pip
   - pip:
     - jupyter-book==0.15.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -37,6 +37,7 @@ latex:
 sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinx_exercise, sphinx_togglebutton, sphinx.ext.intersphinx, sphinx_proof, sphinx_tojupyter] 
   config:
+    bibtex_reference_style: author_year
     # false-positive links
     linkcheck_ignore: ['https://doi.org/https://doi.org/10.2307/1235116', 'https://math.stackexchange.com/*', 'https://stackoverflow.com/*']
     # myst-nb config

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -19,7 +19,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install --upgrade yfinance pandas_datareader interpolation
+!pip install --upgrade yfinance pandas_datareader
 ```
 
 We use the following imports.
@@ -31,7 +31,6 @@ import yfinance as yf
 import pandas as pd
 import statsmodels.api as sm
 
-from interpolation import interp
 from pandas_datareader import wb
 from scipy.stats import norm, cauchy
 from pandas.plotting import register_matplotlib_converters
@@ -602,7 +601,7 @@ def empirical_ccdf(data,
         fw = np.empty_like(aw, dtype='float64')
         for i, a in enumerate(aw):
             fw[i] = a / np.sum(aw)
-        pdf = lambda x: interp(data, fw, x)
+        pdf = lambda x: np.interp(x, data, fw)
         data = np.sort(data)
         j = 0
         for i, d in enumerate(data):

--- a/lectures/inequality.md
+++ b/lectures/inequality.md
@@ -68,7 +68,7 @@ We will install the following libraries.
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install --upgrade quantecon interpolation
+!pip install quantecon
 ```
 
 And we use the following imports.
@@ -79,7 +79,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 import quantecon as qe
 import random as rd
-from interpolation import interp
 ```
 
 ## The Lorenz curve
@@ -746,7 +745,7 @@ Here is one solution:
 
 ```{code-cell} ipython3
 def lorenz2top(f_val, l_val, p=0.1):
-    t = lambda x: interp(f_val, l_val, x)
+    t = lambda x: np.interp(x, f_val, l_val)
     return 1- t(1 - p)
 ```
 

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -1,4 +1,3 @@
-
 ---
 jupytext:
   text_representation:

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -1,3 +1,4 @@
+
 ---
 jupytext:
   text_representation:
@@ -18,6 +19,17 @@ This table contains the latest execution statistics.
 
 (status:machine-details)=
 
-These lectures are built on `linux` instances through `github actions`  and `amazon web services (aws)` to
-enable access to a `gpu`. These lectures are built on a [p3.2xlarge](https://aws.amazon.com/ec2/instance-types/p3/)
-that has access to `8 vcpu's`, a `V100 NVIDIA Tesla GPU`, and `61 Gb` of memory.
+These lectures are built on `linux` instances through `github actions`. 
+
+These lectures are using the following python version
+
+```{code-cell} ipython
+!python --version
+```
+
+and the following package versions
+
+```{code-cell} ipython
+:tags: [hide-output]
+!conda list
+```


### PR DESCRIPTION
This PR

- [x] upgrades to `anaconda=2024.02`
- [x] adopts the new standard README format
- [x] update status page with environment details
- [x] upgrade reference styles
- [x] update `interpolation`
- [x] run a full test build by disabling cache