### PR TITLE
FIX: aligned and general tidy up for new Monetary Lectures

### DIFF
--- a/lectures/laffer_adaptive.md
+++ b/lectures/laffer_adaptive.md
@@ -11,8 +11,6 @@ kernelspec:
   name: python3
 ---
 
-+++ {"user_expressions": []}
-
 # Laffer Curves  with Adaptive Expectations 
 
 ## Overview
@@ -24,8 +22,6 @@ As in the lecture {doc}`money_inflation`, this lecture uses the log-linear versi
 But now, instead of assuming  ''rational expectations'' in the form of ''perfect foresight'',
 we'll adopt the ''adaptive expectations'' assumption used by  {cite}`Cagan` and {cite}`Friedman1956`.
 
-
-
 This means that instead of assuming that expected inflation $\pi_t^*$ is described by the "perfect foresight" or "rational expectations" hypothesis 
 
 $$
@@ -34,20 +30,16 @@ $$
 
 that we adopted in lectures {doc}`money_inflation` and lectures {doc}`money_inflation_nonlinear`, we'll now assume that $\pi_t^*$ is determined by the adaptive expectations hypothesis described in equation {eq}`eq:adaptex`  reported below. 
 
-
-
 We shall discover that changing our hypothesis about expectations formation in this way will change some our findings and leave others intact.  In particular, we shall discover that
 
-
 * replacing rational expectations with adaptive expectations leaves the two stationary inflation rates unchanged, but that $\ldots$ 
-* it reverse the pervese dynamics by making the **lower** stationary inflation rate the one to which the system typically converges
+* it reverse the perverse dynamics by making the **lower** stationary inflation rate the one to which the system typically converges
 * a more plausible comparative dynamic outcome emerges in which now inflation can be **reduced** by running **lower**  government deficits
 
-These more plausible comparative dynamics underly the "old time religion" that states that 
-"inflation is always and everwhere caused by government deficits".
+These more plausible comparative dynamics underlie the "old time religion" that states that 
+"inflation is always and everywhere caused by government deficits".
 
-
-These issues were studyied  by {cite}`bruno1990seigniorage`.
+These issues were studied by {cite}`bruno1990seigniorage`.
 
 Their purpose was to reverse  what they thought were counter intuitive
 predictions of their model under rational expectations (i.e., perfect foresight in this context)
@@ -58,22 +50,19 @@ by dropping rational expectations and instead assuming that people form  expecta
  {cite}`marcet2003recurrent` and  {cite}`sargent2009conquest` extended that work and applied it to study recurrent high-inflation episodes in Latin America.
 ``` 
 
-
 ## The Model
 
 Let  
 
-  * $m_t$ be the log of the money supply at the beginning of time $t$
-  * $p_t$ be the log of the price level at time $t$
-  * $\pi_t^*$ be the public's expectation of the rate of inflation between $t$ and $t+1$ 
+* $m_t$ be the log of the money supply at the beginning of time $t$
+* $p_t$ be the log of the price level at time $t$
+* $\pi_t^*$ be the public's expectation of the rate of inflation between $t$ and $t+1$ 
   
-
 The law of motion of the money supply is
 
 $$ 
 \exp(m_{t+1}) - \exp(m_t) = g \exp(p_t) 
 $$ (eq:ada_msupply)
-
 
 where $g$ is the part of government expenditures financed by printing money.
 
@@ -91,8 +80,6 @@ $$ (eq:ada_mdemand)
 
 where $\alpha \geq 0$.  
 
-
-
 Expectations of inflation are governed by 
 
 $$
@@ -100,7 +87,6 @@ $$
 $$ (eq:adaptex)
 
 where $\delta \in (0,1)$
-
 
 ## Computing An Equilibrium Sequence 
 
@@ -110,7 +96,6 @@ the following equation for $p_t$:
 $$
 \log[ \exp(m_t) + g \exp(p_t)] - p_t = -\alpha [(1-\delta) (p_t - p_{t-1}) + \delta \pi_{t-1}^*]
 $$ (eq:pequation)
-
 
 **Pseudo-code**
 
@@ -131,19 +116,17 @@ This completes the algorithm.
   
 It will turn out that 
 
- * if they exist, limiting values $\overline \pi$ and $\overline \mu$ will be equal
- 
- * if  limiting values exists, there are two possible limiting values, one high, one low
- 
- * unlike the outcome in lecture {doc}`money_inflation_nonlinear`, for almost all initial log price levels and expected inflation rates $p_0, \pi_{t}^*$, the limiting $\overline \pi = \overline \mu$ is  the **lower** steady state  value
- 
- * for each of the two possible limiting values $\bar \pi$ ,there is a unique initial log price level $p_0$ that implies that $\pi_t = \mu_t = \bar \mu$ for all  $t \geq 0$
- 
-    * this unique initial log price level solves $\log(\exp(m_0) + g \exp(p_0)) - p_0 = - \alpha \bar \pi $
-    
-    * the preceding equation for $p_0$ comes from $m_1 - p_0 = -  \alpha \bar \pi$
+* if they exist, limiting values $\overline \pi$ and $\overline \mu$ will be equal
 
-+++ {"user_expressions": []}
+* if  limiting values exists, there are two possible limiting values, one high, one low
+
+* unlike the outcome in lecture {doc}`money_inflation_nonlinear`, for almost all initial log price levels and expected inflation rates $p_0, \pi_{t}^*$, the limiting $\overline \pi = \overline \mu$ is  the **lower** steady state  value
+
+* for each of the two possible limiting values $\bar \pi$ ,there is a unique initial log price level $p_0$ that implies that $\pi_t = \mu_t = \bar \mu$ for all  $t \geq 0$
+
+  * this unique initial log price level solves $\log(\exp(m_0) + g \exp(p_0)) - p_0 = - \alpha \bar \pi $
+  
+  * the preceding equation for $p_0$ comes from $m_1 - p_0 = -  \alpha \bar \pi$
 
 ## Limiting Values of Inflation Rate
 
@@ -180,8 +163,6 @@ Soon  we'll plot  the left and right sides of equation {eq}`eq:ada_steadypi`.
 But first we'll write code that computes a steady-state
 $\bar \pi$.
 
-
-
 Let's start by importing some  libraries
 
 ```{code-cell} ipython3
@@ -213,8 +194,6 @@ def create_model(α=0.5, m0=np.log(100), g=0.35, δ=0.9):
 model = create_model()
 ```
 
-+++ {"user_expressions": []}
-
 Now we write code that computes steady-state $\bar \pi$s.
 
 ```{code-cell} ipython3
@@ -232,11 +211,7 @@ def solve_π_bar(model, x0):
 print(f'The two steady state of π are: {π_l, π_u}')
 ```
 
-+++ {"user_expressions": []}
-
 We find two steady state $\bar \pi$ values
-
-+++ {"user_expressions": []}
 
 ## Steady State Laffer Curve
 
@@ -283,12 +258,9 @@ def plot_laffer(model, πs):
 plot_laffer(model, (π_l, π_u))
 ```
 
-+++ {"user_expressions": []}
-
 ## Associated Initial Price Levels
 
-
- Now that we have our hands on the two possible steady states, we can compute two initial log price levels $p_{-1}$, which as initial conditions, imply that $\pi_t = \bar \pi $ for all $t \geq 0$.
+Now that we have our hands on the two possible steady states, we can compute two initial log price levels $p_{-1}$, which as initial conditions, imply that $\pi_t = \bar \pi $ for all $t \geq 0$.
 
 In particular, to initiate a fixed point of the dynamic Laffer curve dynamics we set 
 
@@ -307,15 +279,9 @@ p_l, p_u = map(lambda π: solve_p_init(model, π), (π_l, π_u))
 print('Associated initial p_{-1}s', f'are: {p_l, p_u}')
 ```
 
-+++ {"user_expressions": []}
-
 ### Verification 
 
-
-
 To start, let's write some code to verify that if we initial  $\pi_{-1}^*,p_{-1}$ appropriately, the inflation rate $\pi_t$ will be constant for all $t \geq 0$ (at either $\pi_u$ or $\pi_l$ depending on the initial condition)
-
-
 
 The following code verifies this.
 
@@ -352,8 +318,6 @@ def solve_laffer_adapt(p_init, π_init, model, num_steps):
     return π_seq, μ_seq, m_seq, p_seq
 ```
 
-+++ {"user_expressions": []}
-
 Compute limiting values starting from $p_{-1}$ associated with $\pi_l$
 
 ```{code-cell} ipython3
@@ -368,8 +332,6 @@ eq_g = lambda x: np.exp(-model.α * x) - np.exp(-(1 + model.α) * x)
 
 print('eq_g == g:', np.isclose(eq_g(m_seq[-1] - m_seq[-2]), model.g))
 ```
-
-+++ {"user_expressions": []}
 
 Compute limiting values starting from $p_{-1}$ associated with $\pi_u$
 
@@ -386,14 +348,9 @@ eq_g = lambda x: np.exp(-model.α * x) - np.exp(-(1 + model.α) * x)
 print('eq_g == g:', np.isclose(eq_g(m_seq[-1] - m_seq[-2]), model.g))
 ```
 
-+++ {"user_expressions": []}
-
 ## Slippery Side of Laffer Curve Dynamics
 
-
-
 We are now equipped  to compute  time series starting from different $p_{-1}, \pi_{-1}^*$ settings, analogous to those in this lecture  {doc}`money_inflation` and this lecture  {doc}`money_inflation_nonlinear`. 
-
 
 Now we'll study how outcomes unfold when we start $p_{-1}, \pi_{-1}^*$ away from a stationary point of the dynamic Laffer curve, i.e., away from either $\pi_u$ or $ \pi_l$.
 
@@ -401,8 +358,6 @@ To construct a perturbation pair $\check p_{-1}, \check \pi_{-1}^*$we'll impleme
 
 * set $\check \pi_{-1}^* $ not equal to one of the stationary points $\pi_u$ or $ \pi_l$.
 * set $\check p_{-1} = m_0 + \alpha \check \pi_{-1}^*$
-
-
 
 ```{code-cell} ipython3
 :tags: [hide-cell]
@@ -439,8 +394,6 @@ def draw_iterations(π0s, model, line_params, π_bars, num_steps):
     plt.tight_layout()
     plt.show()
 ```
-
-+++ {"user_expressions": []}
 
 Let's simulate the result generated by varying the initial $\pi_{-1}$ and corresponding $p_{-1}$
 

--- a/lectures/money_inflation.md
+++ b/lectures/money_inflation.md
@@ -193,10 +193,12 @@ This is true in the present model.
 
 In a **steady state** equilibrium of the  model we are studying, 
 
+$$
 \begin{aligned}
 R_t & = \bar R \cr
 b_t & = \bar b
 \end{aligned}
+$$
 
 for $t \geq 0$.  
 
@@ -382,10 +384,13 @@ We shall  deploy two distinct computation strategies.
    * set $R_0 \in [\frac{\gamma_2}{\gamma_1}, R_u]$ and compute $b_0 = \gamma_1 - \gamma_2/R_0$.
 
    * compute sequences $\{R_t, b_t\}_{t=1}^\infty$ of rates of return and real balances that are associated with an equilibrium by solving equation {eq}`eq:bmotion` and {eq}`eq:bdemand` sequentially  for $t \geq 1$:  
-   \begin{aligned}
-b_t & = b_{t-1} R_{t-1} + g \cr
-R_t^{-1} & = \frac{\gamma_1}{\gamma_2} - \gamma_2^{-1} b_t 
-\end{aligned}
+   
+  $$
+  \begin{aligned}
+  b_t & = b_{t-1} R_{t-1} + g \cr
+  R_t^{-1} & = \frac{\gamma_1}{\gamma_2} - \gamma_2^{-1} b_t 
+  \end{aligned}
+  $$
 
    * Construct the associated equilibrium $p_0$ from 
   
@@ -396,10 +401,10 @@ R_t^{-1} & = \frac{\gamma_1}{\gamma_2} - \gamma_2^{-1} b_t
    * compute $\{p_t, m_t\}_{t=1}^\infty$  by solving the following equations sequentially
   
   $$
-   \begin{aligned}
-   p_t & = R_t p_{t-1} \cr
-   m_t & = b_{t-1} p_t 
-   \end{aligned}
+  \begin{aligned}
+  p_t & = R_t p_{t-1} \cr
+  m_t & = b_{t-1} p_t 
+  \end{aligned}
   $$ (eq:method1) 
    
 **Remark 1:** method 1 uses an indirect approach to computing an equilibrium by first computing an equilibrium  $\{R_t, b_t\}_{t=0}^\infty$ sequence and then using it to back out an equilibrium  $\{p_t, m_t\}_{t=0}^\infty$  sequence.
@@ -461,11 +466,13 @@ Start at $t=0$
  
 Then  for $t \geq 1$ construct $(b_t, R_t)$ by
 iterating  on the system 
+
+$$
 \begin{aligned}
 b_t & = b_{t-1} R_{t-1} + g \cr
 R_t^{-1} & = \frac{\gamma_1}{\gamma_2} - \gamma_2^{-1} b_t
 \end{aligned}
-
+$$
 
 When we implement this part of method 1, we shall discover the following  striking 
 outcome:
@@ -608,11 +615,13 @@ $$
 
 where 
 
+$$
 \begin{aligned} H_1 & = \begin{bmatrix} 1 & \gamma_2 \cr
                  1 & 0 \end{bmatrix} \cr
                 H_2 & = \begin{bmatrix} 0 & \gamma_1 \cr
                  1 & g \end{bmatrix}  
 \end{aligned}
+$$
 
 ```{code-cell} ipython3
 H1 = np.array([[1, msm.γ2], 

--- a/lectures/money_inflation.md
+++ b/lectures/money_inflation.md
@@ -11,11 +11,7 @@ kernelspec:
   name: python3
 ---
 
-+++ {"user_expressions": []}
-
 # Money Financed Government Deficits and Price Levels
-
-+++ {"user_expressions": []}
 
 ## Overview
 
@@ -24,13 +20,13 @@ law of motion that governed the supply of money.
 
 The model in this lecture consists of two components
 
- * a demand function for money 
- * a law of motion for the supply of money
+* a demand function for money 
+* a law of motion for the supply of money
  
 The demand function describes the public's demand for "real balances", defined as the ratio of nominal money balances to the price level
 
-  * it assumes that the demand for real balance today varies inversely with the rate of inflation that the public forecasts to prevail between today and tomorrow
-  * it assumes that the public's forecast of that rate of inflation is perfect 
+* it assumes that the demand for real balance today varies inversely with the rate of inflation that the public forecasts to prevail between today and tomorrow
+* it assumes that the public's forecast of that rate of inflation is perfect 
 
 The law of motion for the supply of money assumes that the government prints money to finance government expenditures
 
@@ -67,32 +63,32 @@ This outcome will be used to justify a selection of a stationary inflation rate 
 
 We'll use theses tools from linear algebra:
 
- * matrix multiplication
- * matrix inversion
- * eigenvalues and eigenvectors of a matrix
+* matrix multiplication
+* matrix inversion
+* eigenvalues and eigenvectors of a matrix
 
 
-## Demand  for and Supply of Money
+## Demand for and Supply of Money
 
-We say demand**s** and supp**ies** (plurals) because there is one of each for each $t \geq 0$.
+We say demand**s** and suppl**ies** (plurals) because there is one of each for each $t \geq 0$.
 
 Let 
 
-  * $m_{t+1}$ be the supply of currency at the end of time $t \geq 0$
-  * $m_{t}$ be the supply  of currency brought into time $t$ from time $t-1$
-  * $g$ be the government deficit that is financed by printing currency at $t \geq 1$
-  * $m_{t+1}^d$ be the demand at time $t$ for currency  to bring into time $t+1$
-  * $p_t$ be  the price level at time $t$
-  * $b_t = \frac{m_{t+1}}{p_t}$ is real balances at the end of time $t$ 
-  * $R_t = \frac{p_t}{p_{t+1}} $ be the gross rate of return on currency held from time $t$ to time $t+1$
+* $m_{t+1}$ be the supply of currency at the end of time $t \geq 0$
+* $m_{t}$ be the supply  of currency brought into time $t$ from time $t-1$
+* $g$ be the government deficit that is financed by printing currency at $t \geq 1$
+* $m_{t+1}^d$ be the demand at time $t$ for currency  to bring into time $t+1$
+* $p_t$ be  the price level at time $t$
+* $b_t = \frac{m_{t+1}}{p_t}$ is real balances at the end of time $t$ 
+* $R_t = \frac{p_t}{p_{t+1}} $ be the gross rate of return on currency held from time $t$ to time $t+1$
   
 It is often helpful  to state units in which quantities are measured:
 
-  * $m_t$ and $m_t^d$ are measured in dollars
-  * $g$ is measured in time $t$ goods 
-  * $p_t$ is measured in dollars per time $t$ goods
-  * $R_t$ is measured in time $t+1$ goods per unit of time $t$ goods
-  * $b_t$ is measured in time $t$ goods
+* $m_t$ and $m_t^d$ are measured in dollars
+* $g$ is measured in time $t$ goods 
+* $p_t$ is measured in dollars per time $t$ goods
+* $R_t$ is measured in time $t+1$ goods per unit of time $t$ goods
+* $b_t$ is measured in time $t$ goods
    
   
 Our job now is to specify demand and supply functions for money. 
@@ -102,7 +98,6 @@ We assume that the demand for  currency satisfies the Cagan-like demand function
 $$
 m_{t+1}^d/p_t =\gamma_1 - \gamma_2 \frac{p_{t+1}}{p_t}, \quad t \geq 0
 $$ (eq:demandmoney)
-  
   
 Now we turn to the supply of money.
 
@@ -151,8 +146,8 @@ $$ (eq:bmotion)
 
 where
 
-  * $b_t = \frac{m_{t+1}}{p_t}$ is real balances at the end of period $t$
-  * $R_{t-1} = \frac{p_{t-1}}{p_t}$ is the gross rate of return on real balances held from $t-1$ to $t$
+* $b_t = \frac{m_{t+1}}{p_t}$ is real balances at the end of period $t$
+* $R_{t-1} = \frac{p_{t-1}}{p_t}$ is the gross rate of return on real balances held from $t-1$ to $t$
 
 The demand for real balances is 
 
@@ -174,8 +169,6 @@ $$ (eq:Requation)
 
 Gross real rate of return $\underline R$ is the smallest rate of return on currency 
 that is consistent with a nonnegative demand for real balances.
-
-
 
 We shall describe two distinct but closely related ways of computing a pair   $\{p_t, m_t\}_{t=0}^\infty$ of sequences for the price level and money supply.
 
@@ -213,7 +206,7 @@ g & = \bar b ( 1 - \bar R)  \cr
 \end{aligned}
 $$
 
-Together these equations  imply
+Together these equations imply
 
 $$
 (\gamma_1 + \gamma_2) - \frac{\gamma_2}{\bar R} - \gamma_1 \bar R = g
@@ -260,13 +253,9 @@ $$ (eq:steadyquadratic)
 
 A steady state gross rate of return  $\bar R$ solves quadratic equation {eq}`eq:steadyquadratic`.
 
-
 So two steady states typically exist. 
 
-
-
 ## Some Code
-
 
 Let's start with some imports:
 
@@ -278,10 +267,7 @@ plt.rcParams['figure.dpi'] = 300
 from collections import namedtuple
 ```
 
-
 Let's set some parameter values and compute possible steady state rates of return on currency $\bar R$, the  seigniorage maximizing rate of return on currency, and an object that we'll discuss later, namely, an initial price level $p_0$ associated with the maximum steady state rate of return on currency.
-
-+++
 
 First, we create a `namedtuple` to store parameters so that we can reuse this `namedtuple` in our functions throughout this lecture
 
@@ -370,10 +356,7 @@ print(f'R_l, g_l = {msm.R_l:.4f}, {g2:.4f}')
 
 Now let's compute the maximum steady state amount of seigniorage that could be gathered by printing money and the state state rate of return on money that attains it.
 
-+++
-
 ## Two  Computation Strategies
-
 
 We now proceed to compute equilibria, not necessarily steady states.
 
@@ -381,72 +364,72 @@ We shall  deploy two distinct computation strategies.
 
 ### Method 1 
 
-   * set $R_0 \in [\frac{\gamma_2}{\gamma_1}, R_u]$ and compute $b_0 = \gamma_1 - \gamma_2/R_0$.
+* set $R_0 \in [\frac{\gamma_2}{\gamma_1}, R_u]$ and compute $b_0 = \gamma_1 - \gamma_2/R_0$.
 
-   * compute sequences $\{R_t, b_t\}_{t=1}^\infty$ of rates of return and real balances that are associated with an equilibrium by solving equation {eq}`eq:bmotion` and {eq}`eq:bdemand` sequentially  for $t \geq 1$:  
+* compute sequences $\{R_t, b_t\}_{t=1}^\infty$ of rates of return and real balances that are associated with an equilibrium by solving equation {eq}`eq:bmotion` and {eq}`eq:bdemand` sequentially  for $t \geq 1$:  
    
-  $$
-  \begin{aligned}
-  b_t & = b_{t-1} R_{t-1} + g \cr
-  R_t^{-1} & = \frac{\gamma_1}{\gamma_2} - \gamma_2^{-1} b_t 
-  \end{aligned}
-  $$
+$$
+\begin{aligned}
+b_t & = b_{t-1} R_{t-1} + g \cr
+R_t^{-1} & = \frac{\gamma_1}{\gamma_2} - \gamma_2^{-1} b_t 
+\end{aligned}
+$$
 
-   * Construct the associated equilibrium $p_0$ from 
-  
-   $$
-   p_0 = \frac{m_0}{\gamma_1 - g - \gamma_2/R_0}
-   $$ (eq:p0fromR0)
-   
-   * compute $\{p_t, m_t\}_{t=1}^\infty$  by solving the following equations sequentially
-  
-  $$
-  \begin{aligned}
-  p_t & = R_t p_{t-1} \cr
-  m_t & = b_{t-1} p_t 
-  \end{aligned}
-  $$ (eq:method1) 
+* Construct the associated equilibrium $p_0$ from 
+
+$$
+p_0 = \frac{m_0}{\gamma_1 - g - \gamma_2/R_0}
+$$ (eq:p0fromR0)
+
+* compute $\{p_t, m_t\}_{t=1}^\infty$  by solving the following equations sequentially
+
+$$
+\begin{aligned}
+p_t & = R_t p_{t-1} \cr
+m_t & = b_{t-1} p_t 
+\end{aligned}
+$$ (eq:method1) 
    
 **Remark 1:** method 1 uses an indirect approach to computing an equilibrium by first computing an equilibrium  $\{R_t, b_t\}_{t=0}^\infty$ sequence and then using it to back out an equilibrium  $\{p_t, m_t\}_{t=0}^\infty$  sequence.
 
 
- **Remark 2:** notice that  method 1 starts by picking an **initial condition** $R_0$ from a set $[\frac{\gamma_2}{\gamma_1}, R_u]$. An equilibrium $\{p_t, m_t\}_{t=0}^\infty$ sequences are not unique.  There is actually a continuum of equilibria indexed by a choice of $R_0$ from the set $[\frac{\gamma_2}{\gamma_1}, R_u]$. 
+**Remark 2:** notice that  method 1 starts by picking an **initial condition** $R_0$ from a set $[\frac{\gamma_2}{\gamma_1}, R_u]$. An equilibrium $\{p_t, m_t\}_{t=0}^\infty$ sequences are not unique.  There is actually a continuum of equilibria indexed by a choice of $R_0$ from the set $[\frac{\gamma_2}{\gamma_1}, R_u]$. 
 
- **Remark 3:** associated with each selection of $R_0$ there is a unique $p_0$ described by
- equation {eq}`eq:p0fromR0`.
+**Remark 3:** associated with each selection of $R_0$ there is a unique $p_0$ described by
+equation {eq}`eq:p0fromR0`.
  
 ### Method 2
 
-   This method deploys a direct approach. 
-   It defines a "state vector" 
-    $y_t = \begin{bmatrix} m_t \cr p_t\end{bmatrix} $
-   and formulates  equilibrium conditions {eq}`eq:demandmoney`, {eq}`eq:budgcontraint`, and
-   {eq}`eq:syeqdemand`
- in terms of a first-order vector difference equation
+This method deploys a direct approach. 
+It defines a "state vector" 
+$y_t = \begin{bmatrix} m_t \cr p_t\end{bmatrix} $
+and formulates  equilibrium conditions {eq}`eq:demandmoney`, {eq}`eq:budgcontraint`, and
+{eq}`eq:syeqdemand`
+in terms of a first-order vector difference equation
 
-   $$
-   y_{t+1} = M y_t, \quad t \geq 0 ,
-   $$
+$$
+y_{t+1} = M y_t, \quad t \geq 0 ,
+$$
 
-   where we temporarily take $y_0 = \begin{bmatrix} m_0 \cr p_0 \end{bmatrix}$ as an **initial condition**. 
-   
-   The solution is 
-   
-   $$
-   y_t = M^t y_0 .
-   $$
+where we temporarily take $y_0 = \begin{bmatrix} m_0 \cr p_0 \end{bmatrix}$ as an **initial condition**. 
 
-   Now let's think about the initial condition $y_0$. 
-   
-   It is natural to take the initial stock of money $m_0 >0$ as an initial condition.
-   
-   But what about $p_0$?  
-   
-   Isn't it  something that we want  to be **determined** by our model?
+The solution is 
 
-   Yes, but sometimes we want too much, because there is actually a continuum of initial $p_0$ levels that are compatible with the existence of an equilibrium.  
-   
-   As we shall see soon, selecting an initial $p_0$ in method 2 is intimately tied to selecting an initial rate of return on currency $R_0$ in method 1. 
+$$
+y_t = M^t y_0 .
+$$
+
+Now let's think about the initial condition $y_0$. 
+
+It is natural to take the initial stock of money $m_0 >0$ as an initial condition.
+
+But what about $p_0$?  
+
+Isn't it  something that we want  to be **determined** by our model?
+
+Yes, but sometimes we want too much, because there is actually a continuum of initial $p_0$ levels that are compatible with the existence of an equilibrium.  
+
+As we shall see soon, selecting an initial $p_0$ in method 2 is intimately tied to selecting an initial rate of return on currency $R_0$ in method 1. 
    
 ## Computation Method 1  
 
@@ -461,8 +444,8 @@ Remember that there exist  two steady state equilibrium  values $ R_l <  R_u$  o
 We proceed as follows.
 
 Start at $t=0$ 
- * select a  $R_0 \in [\frac{\gamma_2}{\gamma_1}, R_u]$  
- * compute   $b_0 = \gamma_1 - \gamma_0 R_0^{-1} $ 
+* select a  $R_0 \in [\frac{\gamma_2}{\gamma_1}, R_u]$  
+* compute   $b_0 = \gamma_1 - \gamma_0 R_0^{-1} $ 
  
 Then  for $t \geq 1$ construct $(b_t, R_t)$ by
 iterating  on the system 
@@ -477,18 +460,17 @@ $$
 When we implement this part of method 1, we shall discover the following  striking 
 outcome:
 
- * starting from an $R_0$ in  $[\frac{\gamma_2}{\gamma_1}, R_u]$, we shall find that 
+* starting from an $R_0$ in  $[\frac{\gamma_2}{\gamma_1}, R_u]$, we shall find that 
 $\{R_t\}$ always converges to a limiting "steady state" value  $\bar R$ that depends on the initial
 condition $R_0$.
 
-  * there are only two possible limit points $\{ R_l, R_u\}$. 
-  
-  * for almost every initial condition $R_0$, $\lim_{t \rightarrow +\infty} R_t = R_l$.
-  
-  * if and only if $R_0 = R_u$, $\lim_{t \rightarrow +\infty} R_t = R_u$.
-  
-The quantity   $1 - R_t$ can be interpreted as an **inflation tax rate** that the government imposes on holders of its currency.
+* there are only two possible limit points $\{ R_l, R_u\}$. 
 
+* for almost every initial condition $R_0$, $\lim_{t \rightarrow +\infty} R_t = R_l$.
+
+* if and only if $R_0 = R_u$, $\lim_{t \rightarrow +\infty} R_t = R_u$.
+  
+The quantity $1 - R_t$ can be interpreted as an **inflation tax rate** that the government imposes on holders of its currency.
 
 We shall soon  see that the existence of two steady state rates of return on currency
 that serve to finance the government deficit of $g$ indicates the presence of a **Laffer curve** in the inflation tax rate.  
@@ -586,8 +568,6 @@ draw_paths(R0s, msm, line_params, num_steps=20)
 
 Notice how sequences that  start from $R_0$ in the half-open interval $[R_l, R_u)$ converge to the steady state  associated with  to $ R_l$.
 
-+++ {"user_expressions": []}
-
 ## Computation method 2 
 
 Set $m_t = m_t^d $ for all $t \geq -1$. 
@@ -595,7 +575,7 @@ Set $m_t = m_t^d $ for all $t \geq -1$.
 Let 
 
 $$
-  y_t =  \begin{bmatrix} m_{t} \cr p_{t} \end{bmatrix} .
+y_t =  \begin{bmatrix} m_{t} \cr p_{t} \end{bmatrix} .
 $$
 
 Represent  equilibrium conditions {eq}`eq:demandmoney`, {eq}`eq:budgcontraint`, and    {eq}`eq:syeqdemand` as
@@ -677,7 +657,6 @@ $$
 where $\Lambda$ is a diagonal matrix of eigenvalues and the columns of $Q$ are eigenvectors corresponding to those eigenvalues.
 
 It turns out that  
-
 
 $$
 \begin{bmatrix} {R_l}^{-1} & 0 \cr 
@@ -1009,9 +988,3 @@ On grounds of plausibility, we recommend following many macroeconomists in selec
 As we shall see, we shall accept this recommendation in  lecture {doc}`unpleasant`.
 
 In lecture, {doc}`laffer_adaptive`, we shall explore how  {cite}`bruno1990seigniorage` and others justified this in other ways.
-
-
-
-
-
-

--- a/lectures/money_inflation_nonlinear.md
+++ b/lectures/money_inflation_nonlinear.md
@@ -11,8 +11,6 @@ kernelspec:
   name: python3
 ---
 
-+++ {"user_expressions": []}
-
 # Inflation Rate Laffer Curves  
 
 ## Overview
@@ -28,8 +26,7 @@ In particular, our dynamic system is no longer linear in state variables.
 
 Nevertheless, the economic logic underlying an  analysis based on what we called ''method 2''  remains unchanged.  
 
-
-in this lecture we shall discover   qualitatively similar outcomnes to those that we studied  in the lecture  {doc}`money_inflation`.
+in this lecture we shall discover   qualitatively similar outcomes to those that we studied  in the lecture  {doc}`money_inflation`.
 
 That lecture presented a linear version of the model in this lecture.  
 
@@ -40,8 +37,6 @@ As in that  lecture,  we discussed these topics:
 * perverse dynamics under rational expectations in which the system converges to the higher stationary inflation tax rate
 * a peculiar comparative stationary-state analysis connected with that stationary inflation rate that assert that inflation can be **reduced** by running **higher**  government deficits 
 
-
-
 These outcomes will set the stage for the analysis of this lecture {doc}`laffer_adaptive` that studies a version of the present model that  uses a version of "adaptive expectations" instead of rational expectations.
 
 That lecture will show that 
@@ -50,18 +45,12 @@ That lecture will show that
 * it reverse the pervese dynamics by making the **lower** stationary inflation rate the one to which the system typically converges
 * a more plausible comparative dynamic outcome emerges in which now inflation can be **reduced** by running **lower**  government deficits
 
-
-
-
-
-
-
 ## The Model
 
 Let  
 
-  * $m_t$ be the log of the money supply at the beginning of time $t$
-  * $p_t$ be the log of the price level at time $t$
+* $m_t$ be the log of the money supply at the beginning of time $t$
+* $p_t$ be the log of the price level at time $t$
   
 The demand function for money is 
 
@@ -87,7 +76,7 @@ We'll deploy a method similar to **Method 2** used in {doc}`money_inflation`.
 
 We'll take the time $t$ state vector to be $m_t, p_t$.
 
-  * we'll treat $m_t$ as a ''natural state variable'' and $p_t$ as a ''jump'' variable.
+* we'll treat $m_t$ as a ''natural state variable'' and $p_t$ as a ''jump'' variable.
   
 Let
 
@@ -112,33 +101,30 @@ We'll summarize our algorithm with the following pseudo-code.
 
 **Pseudo-code**
 
-  * start for $m_0, p_0$ at time $t =0$
+* start for $m_0, p_0$ at time $t =0$
 
-  * solve {eq}`eq:msupply2` for $m_{t+1}$
-  
-  * solve {eq}`eq:mdemand2` for $p_{t+1} = \lambda^{-1} p_t + (1 - \lambda^{-1}) m_{t+1}$
+* solve {eq}`eq:msupply2` for $m_{t+1}$
 
-  * compute $\pi_t = p_{t+1} - p_t$ and $\mu_t = m_{t+1} - m_t $
-  
-  * iterate on $t$ to convergence of $\pi_t \rightarrow \overline \pi$ and $\mu_t \rightarrow \overline \mu$
-  
+* solve {eq}`eq:mdemand2` for $p_{t+1} = \lambda^{-1} p_t + (1 - \lambda^{-1}) m_{t+1}$
+
+* compute $\pi_t = p_{t+1} - p_t$ and $\mu_t = m_{t+1} - m_t $
+
+* iterate on $t$ to convergence of $\pi_t \rightarrow \overline \pi$ and $\mu_t \rightarrow \overline \mu$
   
 It will turn out that 
 
- * if they exist, limiting values $\overline \pi$ and $\overline \mu$ will be equal
- 
- * if  limiting values exists, there are two possible limiting values, one high, one low
- 
- * for almost all initial log price levels $p_0$, the limiting $\overline \pi = \overline \mu$ is 
- the higher value
- 
- * for each of the two possible limiting values $\bar \pi$ ,there is a unique initial log price level $p_0$ that implies that $\pi_t = \mu_t = \bar \mu$ for all  $t \geq 0$
- 
-    * this unique initial log price level solves $\log(\exp(m_0) + g \exp(p_0)) - p_0 = - \alpha \bar \pi $
-    
-    * the preceding equation for $p_0$ comes from $m_1 - p_0 = -  \alpha \bar \pi$
+* if they exist, limiting values $\overline \pi$ and $\overline \mu$ will be equal
 
-+++ {"user_expressions": []}
+* if  limiting values exists, there are two possible limiting values, one high, one low
+
+* for almost all initial log price levels $p_0$, the limiting $\overline \pi = \overline \mu$ is 
+the higher value
+
+* for each of the two possible limiting values $\bar \pi$ ,there is a unique initial log price level $p_0$ that implies that $\pi_t = \mu_t = \bar \mu$ for all  $t \geq 0$
+
+  * this unique initial log price level solves $\log(\exp(m_0) + g \exp(p_0)) - p_0 = - \alpha \bar \pi $
+  
+  * the preceding equation for $p_0$ comes from $m_1 - p_0 = -  \alpha \bar \pi$
 
 ## Limiting Values of Inflation Rate
 
@@ -174,8 +160,6 @@ Soon  we'll plot  the left and right sides of equation {eq}`eq:steadypi`.
 
 But first we'll write code that computes a steady-state
 $\bar \pi$.
-
-
 
 Let's start by importing some  libraries
 
@@ -224,13 +208,7 @@ def solve_π_bar(model, x0):
 print(f'The two steady state of π are: {π_l, π_u}')
 ```
 
-+++ {"user_expressions": []}
-
 We find two steady state $\bar \pi$ values
-
-+++ {"user_expressions": []}
-
-
 
 ## Steady State Laffer Curve
 
@@ -279,7 +257,7 @@ plot_laffer(model, (π_l, π_u))
 
 ## Associated Initial Price Levels
 
- Now that we have our hands on the two possible steady states, we can compute two initial log price levels $p_0$, which as initial conditions, imply that $\pi_t = \bar \pi $ for all $t \geq 0$.
+Now that we have our hands on the two possible steady states, we can compute two initial log price levels $p_0$, which as initial conditions, imply that $\pi_t = \bar \pi $ for all $t \geq 0$.
 
 ```{code-cell} ipython3
 def solve_p0(p0, m0, α, g, π):
@@ -301,8 +279,6 @@ p0_u = solve_p0_bar(model,
                     π_bar=π_u)
 print(f'Associated initial  p_0s  are: {p0_l, p0_u}')
 ```
-
-+++ {"user_expressions": []}
 
 ### Verification 
 
@@ -343,8 +319,6 @@ eq_g = lambda x: np.exp(-model.α * x) - np.exp(-(1 + model.α) * x)
 
 print('eq_g == g:', np.isclose(eq_g(m_seq[-1] - m_seq[-2]), model.g))
 ```
-
-+++ {"user_expressions": []}
 
 ## Slippery Side of Laffer Curve Dynamics
 
@@ -424,7 +398,6 @@ p0_bars = (p0_l, p0_u)
 draw_iterations(p0s, model, line_params, p0_bars, num_steps=20)
 ```
 
-
 Staring at the paths of price levels in  {numref}`p0_path_nonlin` reveals that almost all paths converge to the **higher** inflation tax rate displayed in the stationary state Laffer curve. displayed in figure  {numref}`laffer_curve_nonlinear`.  
 
 Thus, we have reconfirmed  what we have  called the "perverse" dynamics under rational expectations in which the system converges to the higher of two possible stationary inflation tax rates.
@@ -433,15 +406,14 @@ Those dynamics are "perverse" not only in the sense that they imply that the mon
 
 * the figure indicates that inflation can be **reduced** by running **higher**  government deficits, i.e., by raising more resources through  printing money. 
 
-
 ```{note}
 The same qualitive outcomes prevail in this lecture {doc}`money_inflation` that studies a linear version of the model in this lecture`.
 ```
 
 We discovered that 
 
- * all but one of the equilibrium paths converge to limits in which the higher of two possible stationary inflation tax prevails
- * there is a unique equilibrium path associated with "plausible" statements about how reductions in government deficits affect a stationary  inflation rate
+* all but one of the equilibrium paths converge to limits in which the higher of two possible stationary inflation tax prevails
+* there is a unique equilibrium path associated with "plausible" statements about how reductions in government deficits affect a stationary  inflation rate
 
 As in  this lecture {doc}`money_inflation`,
 on grounds of plausibility, we  again recommend  selecting the unique equilibrium that converges to the lower stationary inflation tax rate. 
@@ -449,4 +421,3 @@ on grounds of plausibility, we  again recommend  selecting the unique equilibriu
 As we shall see, we  accepting  this recommendation is a key ingredient of outcomes of the "unpleasant arithmetic" that we describe in   lecture {doc}`unpleasant`.
 
 In lecture, {doc}`laffer_adaptive`, we shall explore how  {cite}`bruno1990seigniorage` and others justified our equilibrium selection in other ways.
-

--- a/lectures/unpleasant.md
+++ b/lectures/unpleasant.md
@@ -11,7 +11,6 @@ kernelspec:
   name: python3
 ---
 
-<!-- #region user_expressions=[] -->
 # Unpleasant Monetarist Arithmetic 
 
 ## Overview
@@ -46,11 +45,6 @@ It also   characterized the steady state equilibrium from which we work backward
 In addition to learning about ''unpleasant monetarist arithmetic", in this lecture we'll learn how to implement a **fixed point** algorithm for computing an initial price level.
 
 
-<!-- #endregion -->
-
-<!-- #region user_expressions=[] -->
-
-
 ## Setup
 
 Let's start with quick reminders of the model's components set out in our lecture on **Money Supplies and Price Levels**.
@@ -72,8 +66,8 @@ $$ (eq:up_bmotion)
 
 where
 
-  * $b_t = \frac{m_{t+1}}{p_t}$ is real balances at the end of period $t$
-  * $R_{t-1} = \frac{p_{t-1}}{p_t}$ is the gross rate of return on real balances held from $t-1$ to $t$
+* $b_t = \frac{m_{t+1}}{p_t}$ is real balances at the end of period $t$
+* $R_{t-1} = \frac{p_{t-1}}{p_t}$ is the gross rate of return on real balances held from $t-1$ to $t$
 
 The demand for real balances is 
 
@@ -81,14 +75,11 @@ $$
 b_t = \gamma_1 - \gamma_2 R_t^{-1} . 
 $$ (eq:up_bdemand)
 
-
-
 ## Monetary-Fiscal Policy
 
 To the basic model of our lecture on **Money Supplies and Price Levels**, we add inflation-indexed one-period government bonds as an additional  way for the government to finance government expenditures. 
 
 Let $\widetilde R > 1$ be a time-invariant gross real rate of return on government one-period inflation-indexed bonds.
-
 
 With this additional source of funds, the government's budget constraint at time $t \geq 0$ is now
 
@@ -126,7 +117,7 @@ This is a version of a standard constraint on a central bank's **open market ope
 ## An open market operation at $t=0$
 
 Following Sargent and Wallace (1981), we analyze consequences of a central bank policy that 
-uses an open market operation to lower the price level in the face of a peristent fiscal
+uses an open market operation to lower the price level in the face of a persistent fiscal
 deficit that takes the form of a positive $g$.
 
 Just before time $0$, the government chooses $(m_0, B_{-1})$  subject to constraint
@@ -258,7 +249,7 @@ To compute an equilibrium, we deploy the following algorithm.
 
 Given **parameters** include $g, \check m_0, \check B_{-1}, \widetilde R >1, T $
 
-We define a mappying from $p_0$ to $p_0$ as follows.
+We define a mapping from $p_0$ to $p_0$ as follows.
 
 * Set $m_0$ and then compute $B_{-1}$ to satisfy the constraint on time $0$ **open market operations**
 
@@ -508,19 +499,8 @@ plot_path([80, 100], msm)
 Figure  {numref}`fig:unpl1` summarizes outcomes of  two experiments that convey   messages of 
 Sargent and Wallace's **unpleasant monetarist arithmetic** {cite}`sargent1981`.
 
- * An open market operation that reduces the supply of money at time $t=0$ reduces  the price level at time $t=0$
+* An open market operation that reduces the supply of money at time $t=0$ reduces  the price level at time $t=0$
 
 * The lower is the post-open-market-operation money supply at time $0$, lower is the price level at time $0$.
 
 * An open  market operation that reduces the post-open-market-operation money supply at time $0$ also **lowers** the rate of return on money $R_u$ at times $t \geq T$ because it brings  a higher gross-of-interest government deficit that must be financed by printing money (i.e., levying an inflation tax) at time $t \geq T$.
-
-
-
-
-
-
- 
-
-<!-- #endregion -->
-
-

--- a/lectures/unpleasant.md
+++ b/lectures/unpleasant.md
@@ -189,14 +189,16 @@ p_T & = \frac{m_0}{\gamma_1 - \overline g - \gamma_2 R_u^{-1}}
 $$ (eq:LafferTstationary)
 
 
-We can compute continuation sequences $\{R_t, b_t\}_{t=T+1}^\infty$ of rates of return and real balances that are associated with an equilibrium by solving equation {eq}`eq:up_bmotion` and {eq}`eq:up_bdemand` sequentially  for $t \geq 1$:  
-   \begin{aligned}
+We can compute continuation sequences $\{R_t, b_t\}_{t=T+1}^\infty$ of rates of return and real balances that are associated with an equilibrium by solving equation {eq}`eq:up_bmotion` and {eq}`eq:up_bdemand` sequentially  for $t \geq 1$:
+
+$$
+\begin{aligned}
 b_t & = b_{t-1} R_{t-1} + \overline g \cr
 R_t^{-1} & = \frac{\gamma_1}{\gamma_2} - \gamma_2^{-1} b_t \cr
 p_t & = R_t p_{t-1} \cr
    m_t & = b_{t-1} p_t 
 \end{aligned}
-
+$$
    
 
 ## Before time $T$ 


### PR DESCRIPTION
This PR

- [x] fixes some spelling mistakes
- [x] fixes `aligned` use which needs to be inside an equation environment such as `$$`
- [x] removes conversion markup
- [x] minor changes to spacing for readibility