### PR TITLE
Delete %matplotlib inline in all lectures

### DIFF
--- a/lectures/ar1_processes.md
+++ b/lectures/ar1_processes.md
@@ -50,7 +50,6 @@ Let's start with some imports:
 
 ```{code-cell} ipython
 import numpy as np
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 ```

--- a/lectures/geom_series.md
+++ b/lectures/geom_series.md
@@ -53,7 +53,6 @@ These and other applications prove the truth of the wise crack that
 Below we'll use the following imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np

--- a/lectures/lp_intro.md
+++ b/lectures/lp_intro.md
@@ -56,7 +56,6 @@ from ortools.linear_solver import pywraplp
 from scipy.optimize import linprog
 import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
-%matplotlib inline
 ```
 
 Let's start with some examples of linear programming problem.

--- a/lectures/scalar_dynam.md
+++ b/lectures/scalar_dynam.md
@@ -40,7 +40,6 @@ and understand key concepts.
 Let's start with some standard imports:
 
 ```{code-cell} ipython
-%matplotlib inline
 import matplotlib.pyplot as plt
 import numpy as np
 ```

--- a/lectures/schelling.md
+++ b/lectures/schelling.md
@@ -72,7 +72,6 @@ awarded the 2005 Nobel Prize in Economic Sciences (joint with Robert Aumann).
 Let's start with some imports:
 
 ```{code-cell} ipython3
-%matplotlib inline
 import matplotlib.pyplot as plt
 from random import uniform, seed
 from math import sqrt

--- a/lectures/time_series_with_matrices.md
+++ b/lectures/time_series_with_matrices.md
@@ -46,7 +46,6 @@ We will use the following imports:
 
 ```{code-cell} ipython
 import numpy as np
-%matplotlib inline
 import matplotlib.pyplot as plt
 from matplotlib import cm
 plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size


### PR DESCRIPTION
Dear John @jstac ,

This pull request deletes all `%matplotlib inline` in all the lectures. These are the lectures being altered:

- [geom_series]
- [schelling]
- [scaler_dynam]
- [ar1_processes]
- [time_series_with_matrices]
- [lp_intro]

Best ❤️ 
Longye