### PR TITLE
[inflation_history] FIX: compat with Google Colab

### DIFF
--- a/lectures/inflation_history.md
+++ b/lectures/inflation_history.md
@@ -23,6 +23,16 @@ The `xlrd` package is used by `pandas` to perform operations on Excel files.
 !pip install xlrd
 ```
 
+This lecture also requires `pandas >= 2.1.4`
+
+```{code-cell} ipython3
+from packaging.version import Version
+import pandas as pd
+if Version(pd.__version__) < Version('2.1.4'):
+  !pip install pandas==2.1.4
+  reload(pandas)
+```
+
 We can then import the Python modules we will use.
 
 ```{code-cell} ipython3

--- a/lectures/inflation_history.md
+++ b/lectures/inflation_history.md
@@ -20,12 +20,14 @@ Let's start by installing the necessary Python packages.
 The `xlrd` package is used by `pandas` to perform operations on Excel files.
 
 ```{code-cell} ipython3
+:tags: [hide-output]
 !pip install xlrd
 ```
 
 This lecture also requires `pandas >= 2.1.4`
 
 ```{code-cell} ipython3
+:tags: [hide-output]
 from packaging.version import Version
 import pandas as pd
 if Version(pd.__version__) < Version('2.1.4'):


### PR DESCRIPTION
This PR fixes compatibility for `inflation_history` lecture with Google Collab due to an old version of `pandas`. This lecture requires `pandas>=2.1.4` due to the use of `.map`