### PR TITLE
[markov_chain_II] Update figure to avoid overlaps and fix a typo in greeksquare

### DIFF
--- a/lectures/greek_square.md
+++ b/lectures/greek_square.md
@@ -133,10 +133,10 @@ $$
 where $\eta_1$ and $\eta_2$ are chosen to satisfy the  prescribed initial conditions $y_{-1}, y_{-2}$:
 
 $$
-\begin{align}
+\begin{aligned}
 \lambda_1^{-1} \eta_1 + \lambda_2^{-1} \eta_2 & =  y_{-1} \cr
 \lambda_1^{-2} \eta_1 + \lambda_2^{-2} \eta_2 & =  y_{-2}
-\end{align}
+\end{aligned}
 $$(eq:leq_sq)
 
 System {eq}`eq:leq_sq` of simultaneous linear equations will play a big role in the remainder of this lecture.  

--- a/lectures/markov_chains_II.md
+++ b/lectures/markov_chains_II.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.4
+    jupytext_version: 1.16.1
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -248,8 +248,6 @@ Hence we expect that $\hat p_n(x) \approx \psi^*(x)$ when $n$ is large.
 The next figure shows convergence of $\hat p_n(x)$ to $\psi^*(x)$ when $x=1$ and
 $X_0$ is either $0, 1$ or $2$.
 
-
-
 ```{code-cell} ipython3
 P = np.array([[0.971, 0.029, 0.000],
               [0.145, 0.778, 0.077],
@@ -312,7 +310,7 @@ P = np.array([[0, 1],
 ts_length = 10_000
 mc = qe.MarkovChain(P)
 n = len(P)
-fig, axes = plt.subplots(nrows=1, ncols=n)
+fig, axes = plt.subplots(figsize=(11, 5), nrows=1, ncols=n)
 ψ_star = mc.stationary_distributions[0]
 
 for i in range(n):
@@ -394,8 +392,6 @@ for x0 in range(len(P)):
 ax.legend()
 plt.show()
 ```
-
-
 
 ### Expectations of geometric sums
 

--- a/lectures/markov_chains_II.md
+++ b/lectures/markov_chains_II.md
@@ -310,7 +310,7 @@ P = np.array([[0, 1],
 ts_length = 10_000
 mc = qe.MarkovChain(P)
 n = len(P)
-fig, axes = plt.subplots(figsize=(11, 5), nrows=1, ncols=n)
+fig, axes = plt.subplots(nrows=1, ncols=n)
 ψ_star = mc.stationary_distributions[0]
 
 for i in range(n):
@@ -328,6 +328,8 @@ for i in range(n):
         axes[i].plot(p_hat, label=f'$x_0 = \, {x0} $')
 
     axes[i].legend()
+    
+plt.tight_layout()
 plt.show()
 ```
 


### PR DESCRIPTION
The two figures overlap after removing the figure size specification:

![image](https://github.com/QuantEcon/lecture-python-intro/assets/39026988/80d3ca85-817b-4eb8-a81a-68b24863dda9)

This PR adds a tight layout to resolve this issue.

This PR also resolves the issue related to the use of `aligned` in `greeksquare` lecture.