### PR TITLE
remove migration admonition

### DIFF
--- a/lectures/ar1_processes.md
+++ b/lectures/ar1_processes.md
@@ -21,12 +21,6 @@ kernelspec:
 (ar1_processes)=
 # AR1 Processes
 
-```{admonition} Migrated lecture
-:class: warning
-
-This lecture has moved from our [Intermediate Quantitative Economics with Python](https://python.quantecon.org/intro.html) lecture series and is now a part of [A First Course in Quantitative Economics](https://intro.quantecon.org/intro.html).
-```
-
 ```{index} single: Autoregressive processes
 ```
 

--- a/lectures/complex_and_trig.md
+++ b/lectures/complex_and_trig.md
@@ -23,12 +23,6 @@ kernelspec:
 
 # Complex Numbers and Trigonometry
 
-```{admonition} Migrated lecture
-:class: warning
-
-This lecture has moved from our [Intermediate Quantitative Economics with Python](https://python.quantecon.org/intro.html) lecture series and is now a part of [A First Course in Quantitative Economics](https://intro.quantecon.org/intro.html).
-```
-
 ## Overview
 
 This lecture introduces some elementary mathematics and trigonometry.

--- a/lectures/geom_series.md
+++ b/lectures/geom_series.md
@@ -25,12 +25,6 @@ kernelspec:
 
 # Geometric Series for Elementary Economics
 
-```{admonition} Migrated lecture
-:class: warning
-
-This lecture has moved from our [Intermediate Quantitative Economics with Python](https://python.quantecon.org/intro.html) lecture series and is now a part of [A First Course in Quantitative Economics](https://intro.quantecon.org/intro.html).
-```
-
 ## Overview
 
 The lecture describes important ideas in economics that use the mathematics of geometric series.

--- a/lectures/lp_intro.md
+++ b/lectures/lp_intro.md
@@ -12,12 +12,6 @@ kernelspec:
 (lp_intro)=
 # Linear Programming
 
-```{admonition} Migrated lecture
-:class: warning
-
-This lecture has moved from our [Intermediate Quantitative Economics with Python](https://python.quantecon.org/intro.html) lecture series and is now a part of [A First Course in Quantitative Economics](https://intro.quantecon.org/intro.html).
-```
-
 In this lecture, we will need the following library. Install [ortools](https://developers.google.com/optimization) using `pip`.
 
 ```{code-cell} ipython3

--- a/lectures/schelling.md
+++ b/lectures/schelling.md
@@ -28,12 +28,6 @@ kernelspec:
 ```{index} single: Models; Schelling's Segregation Model
 ```
 
-```{admonition} Migrated lecture
-:class: warning
-
-This lecture has moved from our [Intermediate Quantitative Economics with Python](https://python.quantecon.org/intro.html) lecture series and is now a part of [A First Course in Quantitative Economics](https://intro.quantecon.org/intro.html).
-```
-
 ## Outline
 
 In 1969, Thomas C. Schelling developed a simple but striking model of racial

--- a/lectures/short_path.md
+++ b/lectures/short_path.md
@@ -23,12 +23,6 @@ kernelspec:
 ```{index} single: Dynamic Programming; Shortest Paths
 ```
 
-```{admonition} Migrated lecture
-:class: warning
-
-This lecture has moved from our [Intermediate Quantitative Economics with Python](https://python.quantecon.org/intro.html) lecture series and is now a part of [A First Course in Quantitative Economics](https://intro.quantecon.org/intro.html).
-```
-
 ## Overview
 
 The shortest path problem is a [classic problem](https://en.wikipedia.org/wiki/Shortest_path) in mathematics and computer science with applications in


### PR DESCRIPTION
Hi @mmcky,

This pull request is related to #465  and removes the migration admonition from the following lectures.

- ar1_processes.md
- complex_and_trig.md
- geom_series.md
- lp_intro.md
- schelling.md
- short_path.md

Best regards,
Longye