### PR TITLE
[markov_chain_I] update periodic matrix section

### DIFF
--- a/lectures/markov_chains_I.md
+++ b/lectures/markov_chains_I.md
@@ -933,7 +933,7 @@ P =
 \end{bmatrix}
 $$
 
-We observe that certain initial distributions cycle periodically rather than converge. 
+We observe that certain initial distributions cycle periodically rather than converging. 
 
 For instance, the distribution (1,0) alternates to (0,1) and back again. 
 

--- a/lectures/markov_chains_I.md
+++ b/lectures/markov_chains_I.md
@@ -933,7 +933,7 @@ P =
 \end{bmatrix}
 $$
 
-We observe that certain initial distributions cycle periodically rather than converging. 
+We observe that certain initial distributions cycle periodically rather than converge. 
 
 For instance, the distribution (1,0) alternates to (0,1) and back again. 
 


### PR DESCRIPTION
Dear John @jstac ,

This pull request is to update the visualization and explanation of the periodic matrix section:

- change the explanation by using an example to demonstrate.

- update the animation code with the unique stationary distribution.

- add an explanation of the visualization code

The updated visualization is shown below:


https://github.com/QuantEcon/lecture-python-intro/assets/133612246/3d6cdc3a-4ddb-43d2-8e69-4f53d14b62bb

What do you think about these changes? 

Best ❤️ 
Longye