### PR TITLE
[scalar_dynam] add explanation to parameters and add explanation of k

### DIFF
--- a/lectures/scalar_dynam.md
+++ b/lectures/scalar_dynam.md
@@ -220,11 +220,10 @@ For example, in a later lecture {doc}`solow`, we will study the Solow-Swan growt
 ```{math}
 :label: solow_lom2
 
-k_{t+1} = s z k_t^{\alpha} + (1 - \delta) k_t
+k_{t+1} = s A k_t^{\alpha} + (1 - \delta) k_t
 ```
 
-Here $k$ is the per capita capital stock and $s, z, \alpha, \delta$ are positive
-parameters with $0 < \alpha, \delta < 1$.
+Here $k=K/L$ is the per capita capital stock, $s$ is the saving rate, $A$ is the total factor productivity, $\alpha$ is the capital share, and $\delta$ is the depreciation rate. All these parameter are positive and $0 < \alpha, \delta < 1$.
 
 If you try to iterate like we did in {eq}`sdslinmodpath`, you will find that
 the algebra gets messy quickly.

--- a/lectures/scalar_dynam.md
+++ b/lectures/scalar_dynam.md
@@ -223,7 +223,9 @@ For example, in a later lecture {doc}`solow`, we will study the Solow-Swan growt
 k_{t+1} = s A k_t^{\alpha} + (1 - \delta) k_t
 ```
 
-Here $k=K/L$ is the per capita capital stock, $s$ is the saving rate, $A$ is the total factor productivity, $\alpha$ is the capital share, and $\delta$ is the depreciation rate. All these parameter are positive and $0 < \alpha, \delta < 1$.
+Here $k=K/L$ is the per capita capital stock, $s$ is the saving rate, $A$ is the total factor productivity, $\alpha$ is the capital share, and $\delta$ is the depreciation rate. 
+
+All these parameter are positive and $0 < \alpha, \delta < 1$.
 
 If you try to iterate like we did in {eq}`sdslinmodpath`, you will find that
 the algebra gets messy quickly.


### PR DESCRIPTION
Dear John @jstac and Matt @mmcky ,

This pull request is to update the suggestions with high priority in lecture scalar_dynam.md according #526.

In particular this pull request

- add explanation to all the parameters in the Solow-Swan model, 
- change 'z' to 'A' to match with the notation in the Solow-Swan lecture.
- Add 'k=K/L' to denote per capita capital stock.

What do you think about these changes? Would you like to change anything?


Best ❤️ 
Longye