### PR TITLE
[ar1_processes] to [eigen_II] [heavy_tails][inequality]Example and spelling

### DIFF
--- a/lectures/ar1_processes.md
+++ b/lectures/ar1_processes.md
@@ -60,6 +60,9 @@ where $a, b, c$ are scalar-valued parameters
 
 (Equation {eq}`can_ar1` is sometimes called a **stochastic difference equation**.)
 
+```{prf:example}
+:label: ar1_ex_ar
+
 For example, $X_t$ might be 
 
 * the log of labor income for a given household, or
@@ -70,6 +73,7 @@ of the previous value and an IID shock $W_{t+1}$.
 
 (We use $t+1$ for the subscript of $W_{t+1}$ because this random variable is not
 observed at time $t$.)
+```
 
 The specification {eq}`can_ar1` generates a time series $\{ X_t\}$ as soon as we
 specify an initial condition $X_0$.
@@ -330,7 +334,10 @@ Notes:
 * In {eq}`ar1_ergo`, convergence holds with probability one.
 * The textbook by {cite}`MeynTweedie2009` is a classic reference on ergodicity.
 
-For example, if we consider the identity function $h(x) = x$, we get
+```{prf:example}
+:label: ar1_ex_id
+
+If we consider the identity function $h(x) = x$, we get
 
 $$
 \frac{1}{m} \sum_{t = 1}^m X_t  \to
@@ -339,7 +346,7 @@ $$
 $$
 
 In other words, the time series sample mean converges to the mean of the stationary distribution.
-
+```
 
 Ergodicity is important for a range of reasons.
 

--- a/lectures/cagan_ree.md
+++ b/lectures/cagan_ree.md
@@ -18,7 +18,7 @@ kernelspec:
 
 We'll use linear algebra first to explain and then do some experiments with a "monetarist theory of price levels".
 
-Economists call it a "monetary" or "monetarist" theory of price levels because effects on price levels occur via a central banks's decisions to print money supply. 
+Economists call it a "monetary" or "monetarist" theory of price levels because effects on price levels occur via a central bank's decisions to print money supply. 
 
   * a goverment's fiscal policies determine whether its _expenditures_ exceed its _tax collections_
   * if its expenditures exceed its tax collections, the government can instruct the central bank to cover the difference by _printing money_
@@ -27,7 +27,7 @@ Economists call it a "monetary" or "monetarist" theory of price levels because e
 Such a theory of price levels was described by Thomas Sargent and Neil Wallace in chapter 5 of 
 {cite}`sargent2013rational`, which reprints a 1981 Federal Reserve Bank of Minneapolis article entitled "Unpleasant Monetarist Arithmetic". 
 
-Sometimes this theory is also called a "fiscal theory of price levels" to emphasize the importance of fisal deficits in shaping changes in the money supply. 
+Sometimes this theory is also called a "fiscal theory of price levels" to emphasize the importance of fiscal deficits in shaping changes in the money supply. 
 
 The theory has been extended, criticized, and applied by John Cochrane {cite}`cochrane2023fiscal`.
 
@@ -41,7 +41,7 @@ persistent inflation.
 
 The "monetarist" or "fiscal theory of price levels" asserts that 
 
-* to _start_ a persistent inflation the government beings persistently to run a money-financed government deficit
+* to _start_ a persistent inflation the government begins persistently to run a money-financed government deficit
 
 * to _stop_ a persistent inflation the government stops persistently running a money-financed government deficit
 

--- a/lectures/complex_and_trig.md
+++ b/lectures/complex_and_trig.md
@@ -103,12 +103,16 @@ from sympy import (Symbol, symbols, Eq, nsolve, sqrt, cos, sin, simplify,
 
 ### An Example
 
+```{prf:example}
+:label: ct_ex_com
+
 Consider the complex number $z = 1 + \sqrt{3} i$.
 
 For $z = 1 + \sqrt{3} i$, $x = 1$, $y = \sqrt{3}$.
 
 It follows that $r = 2$ and
 $\theta = \tan^{-1}(\sqrt{3}) = \frac{\pi}{3} = 60^o$.
+```
 
 Let's use Python to plot the trigonometric form of the complex number
 $z = 1 + \sqrt{3} i$.

--- a/lectures/cons_smooth.md
+++ b/lectures/cons_smooth.md
@@ -21,7 +21,7 @@ In this lecture, we'll study a famous model of the "consumption function" that M
 
 In this lecture, we'll study what is often  called the "consumption-smoothing model"  using  matrix multiplication and matrix inversion, the same tools that we used in this QuantEcon lecture {doc}`present values <pv>`. 
 
-Formulas presented in  {doc}`present value formulas<pv>` are at the core of the consumption smoothing model because we shall use them to define a consumer's "human wealth".
+Formulas presented in  {doc}`present value formulas<pv>` are at the core of the consumption-smoothing model because we shall use them to define a consumer's "human wealth".
 
 The  key idea that inspired Milton Friedman was that a person's non-financial income, i.e., his or
 her wages from working, could be viewed as a dividend stream from that person's ''human capital''
@@ -39,7 +39,7 @@ It will take a while for a "present value" or asset price explicilty to appear i
 
 ## Analysis
 
-As usual, we'll start with by importing some Python modules.
+As usual, we'll start by importing some Python modules.
 
 ```{code-cell} ipython3
 import numpy as np
@@ -128,7 +128,7 @@ Indeed, we shall see that when $\beta R = 1$ (a condition assumed by Milton Frie
 
 By **smoother** we mean as close as possible to being constant over time.  
 
-The preference for smooth consumption paths that is built into the model gives it the  name "consumption smoothing model".
+The preference for smooth consumption paths that is built into the model gives it the  name "consumption-smoothing model".
 
 Let's dive in and do some calculations that will help us understand how the model works. 
 
@@ -176,7 +176,7 @@ $$
 \sum_{t=0}^T R^{-t} c_t = a_0 + h_0. 
 $$ (eq:budget_intertemp)
 
-Equation {eq}`eq:budget_intertemp`  says that the present value of the consumption stream equals the sum of finanical and non-financial (or human) wealth.
+Equation {eq}`eq:budget_intertemp`  says that the present value of the consumption stream equals the sum of financial and non-financial (or human) wealth.
 
 Robert Hall {cite}`Hall1978` showed that when $\beta R = 1$, a condition Milton Friedman had also  assumed, it is "optimal" for a consumer to smooth consumption by setting 
 
@@ -196,7 +196,7 @@ $$ (eq:conssmoothing)
 Equation {eq}`eq:conssmoothing` is the consumption-smoothing model in a nutshell.
 
 
-## Mechanics of Consumption smoothing model  
+## Mechanics of consumption-smoothing model  
 
 As promised, we'll provide step-by-step instructions on how to use linear algebra, readily implemented in Python, to compute all  objects in play in  the consumption-smoothing model.
 
@@ -338,14 +338,14 @@ print('Welfare:', welfare(cs_model, c_seq))
 
 ### Experiments
 
-In this section we decribe  how a  consumption sequence would optimally respond to different  sequences sequences of non-financial income.
+In this section we describe  how a  consumption sequence would optimally respond to different  sequences sequences of non-financial income.
 
-First we create  a function `plot_cs` that generate graphs for different instances of the  consumption smoothing model `cs_model`.
+First we create  a function `plot_cs` that generates graphs for different instances of the  consumption-smoothing model `cs_model`.
 
 This will  help us avoid rewriting code to plot outcomes for different non-financial income sequences.
 
 ```{code-cell} ipython3
-def plot_cs(model,    # consumption smoothing model      
+def plot_cs(model,    # consumption-smoothing model      
             a0,       # initial financial wealth
             y_seq     # non-financial income process
            ):
@@ -368,7 +368,7 @@ def plot_cs(model,    # consumption smoothing model
     plt.show()
 ```
 
-In the experiments below, please study how consumption and financial asset sequences vary accross different sequences for non-financial income.
+In the experiments below, please study how consumption and financial asset sequences vary across different sequences for non-financial income.
 
 #### Experiment 1: one-time gain/loss
 
@@ -602,7 +602,7 @@ First, we define the welfare with respect to $\xi_1$ and $\phi$
 def welfare_rel(ξ1, ϕ):
     """
     Compute welfare of variation sequence 
-    for given ϕ, ξ1 with a consumption smoothing model
+    for given ϕ, ξ1 with a consumption-smoothing model
     """
     
     cvar_seq = compute_variation(cs_model, ξ1=ξ1, 
@@ -661,13 +661,13 @@ QuantEcon lecture {doc}`geometric series <geom_series>`.
 In particular,  it  **lowers** the government expenditure  multiplier relative to  one implied by
 the original Keynesian consumption function presented in {doc}`geometric series <geom_series>`.
 
-Friedman's   work opened the door to an enlighening literature on the aggregate consumption function and associated government expenditure  multipliers that
+Friedman's   work opened the door to an enlightening literature on the aggregate consumption function and associated government expenditure  multipliers that
 remains  active today.  
 
 
 ## Appendix: solving difference equations with linear algebra
 
-In the preceding sections we have used linear algebra to solve a consumption smoothing model.  
+In the preceding sections we have used linear algebra to solve a consumption-smoothing model.  
 
 The same tools from linear algebra -- matrix multiplication and matrix inversion -- can be used  to study many other dynamic models.
 
@@ -749,7 +749,7 @@ is the inverse of $A$ and check that $A A^{-1} = I$
 
 ```
 
-### Second order difference equation
+### Second-order difference equation
 
 A second-order linear difference equation for $\{y_t\}_{t=0}^T$ is
 
@@ -783,6 +783,6 @@ Multiplying both sides by  inverse of the matrix on the left again provides the 
 ```{exercise}
 :label: consmooth_ex2
 
-As an exercise, we ask you to represent and solve a **third order linear difference equation**.
+As an exercise, we ask you to represent and solve a **third-order linear difference equation**.
 How many initial conditions must you specify?
 ```

--- a/lectures/eigen_I.md
+++ b/lectures/eigen_I.md
@@ -88,7 +88,8 @@ itself.
 This means $A$ is an $n \times n$ matrix that maps (or "transforms") a vector
 $x$ in $\mathbb{R}^n$ to a new vector $y=Ax$ also in $\mathbb{R}^n$.
 
-Here's one example:
+```{prf:example}
+:label: eigen1_ex_sq
 
 $$
     \begin{bmatrix}
@@ -116,6 +117,7 @@ $$
 
 transforms the vector $x = \begin{bmatrix} 1 \\ 3 \end{bmatrix}$ to the vector
 $y = \begin{bmatrix} 5 \\ 2 \end{bmatrix}$.
+```
 
 Let's visualize this using Python:
 

--- a/lectures/eigen_II.md
+++ b/lectures/eigen_II.md
@@ -64,6 +64,9 @@ An $n \times n$ nonnegative matrix $A$ is called irreducible if $A + A^2 + A^3 +
 
 In other words, for each $i,j$ with $1 \leq i, j \leq n$, there exists a $k \geq 0$ such that $a^{k}_{ij} > 0$.
 
+```{prf:example}
+:label: eigen2_ex_irr
+
 Here are some examples to illustrate this further:
 
 $$
@@ -94,6 +97,7 @@ $$
 
 $C$ is not irreducible since $C^k = C$ for all $k \geq 0$ and thus
    $c^{k}_{12},c^{k}_{21} = 0$ for all $k \geq 0$.
+```
 
 ### Left eigenvectors
 
@@ -188,7 +192,7 @@ Let's build our intuition for the theorem using a simple example we have seen [b
 
 Now let's consider examples for each case.
 
-#### Example: Irreducible matrix
+#### Example: irreducible matrix
 
 Consider the following irreducible matrix $A$:
 
@@ -223,6 +227,9 @@ Let $A$ be a square nonnegative matrix and let $A^k$ be the $k^{th}$ power of $A
 
 A matrix is called **primitive** if there exists a $k \in \mathbb{N}$ such that $A^k$ is everywhere positive.
 
+```{prf:example}
+:label: eigen2_ex_prim
+
 Recall the examples given in irreducible matrices:
 
 $$
@@ -244,6 +251,7 @@ B^2 = \begin{bmatrix} 1 & 0 \\
 $$
 
 $B$ is irreducible but not primitive since there are always zeros in either principal diagonal or secondary diagonal.
+```
 
 We can see that if a matrix is primitive, then it implies the matrix is irreducible but not vice versa.
 

--- a/lectures/eigen_II.md
+++ b/lectures/eigen_II.md
@@ -26,7 +26,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 
 In this lecture we will begin with the foundational concepts in spectral theory.
 
-Then we will explore the Perron-Frobenius Theorem and connect it to applications in Markov chains and networks.
+Then we will explore the Perron-Frobenius theorem and connect it to applications in Markov chains and networks.
 
 We will use the following imports:
 
@@ -159,7 +159,7 @@ This is a more common expression and where the name left eigenvectors originates
 For a square nonnegative matrix $A$, the behavior of $A^k$ as $k \to \infty$ is controlled by the eigenvalue with the largest
 absolute value, often called the **dominant eigenvalue**.
 
-For any such matrix $A$, the Perron-Frobenius Theorem characterizes certain
+For any such matrix $A$, the Perron-Frobenius theorem characterizes certain
 properties of the dominant eigenvalue and its corresponding eigenvector.
 
 ```{prf:Theorem} Perron-Frobenius Theorem
@@ -204,7 +204,7 @@ We can compute the dominant eigenvalue and the corresponding eigenvector
 eig(A)
 ```
 
-Now we can see the claims of the Perron-Frobenius Theorem holds for the irreducible matrix $A$:
+Now we can see the claims of the Perron-Frobenius theorem holds for the irreducible matrix $A$:
 
 1. The dominant eigenvalue is real-valued and non-negative.
 2. All other eigenvalues have absolute values less than or equal to the dominant eigenvalue.
@@ -247,7 +247,7 @@ $B$ is irreducible but not primitive since there are always zeros in either prin
 
 We can see that if a matrix is primitive, then it implies the matrix is irreducible but not vice versa.
 
-Now let's step back to the primitive matrices part of the Perron-Frobenius Theorem
+Now let's step back to the primitive matrices part of the Perron-Frobenius theorem
 
 ```{prf:Theorem} Continous of Perron-Frobenius Theorem
 :label: con-perron-frobenius
@@ -259,7 +259,7 @@ If $A$ is primitive then,
 $ r(A)^{-m} A^m$ converges to $v w^{\top}$ when $m \rightarrow \infty$. The matrix $v w^{\top}$ is called the **Perron projection** of $A$.
 ```
 
-#### Example 1: Primitive matrix
+#### Example 1: primitive matrix
 
 Consider the following primitive matrix $B$:
 
@@ -277,7 +277,7 @@ We compute the dominant eigenvalue and the corresponding eigenvector
 eig(B)
 ```
 
-Now let's give some examples to see if the claims of the Perron-Frobenius Theorem hold for the primitive matrix $B$:
+Now let's give some examples to see if the claims of the Perron-Frobenius theorem hold for the primitive matrix $B$:
 
 1. The dominant eigenvalue is real-valued and non-negative.
 2. All other eigenvalues have absolute values strictly less than the dominant eigenvalue.
@@ -373,18 +373,18 @@ check_convergence(B)
 
 The result shows that the matrix is not primitive as it is not everywhere positive.
 
-These examples show how the Perron-Frobenius Theorem relates to the eigenvalues and eigenvectors of positive matrices and the convergence of the power of matrices.
+These examples show how the Perron-Frobenius theorem relates to the eigenvalues and eigenvectors of positive matrices and the convergence of the power of matrices.
 
 In fact we have already seen the theorem in action before in {ref}`the Markov chain lecture <mc1_ex_1>`.
 
 (spec_markov)=
-#### Example 2: Connection to Markov chains
+#### Example 2: connection to Markov chains
 
 We are now prepared to bridge the languages spoken in the two lectures.
 
 A primitive matrix is both irreducible and aperiodic.
 
-So Perron-Frobenius Theorem explains why both {ref}`Imam and Temple matrix <mc_eg3>` and [Hamilton matrix](https://en.wikipedia.org/wiki/Hamiltonian_matrix) converge to a stationary distribution, which is the Perron projection of the two matrices
+So Perron-Frobenius theorem explains why both {ref}`Imam and Temple matrix <mc_eg3>` and [Hamilton matrix](https://en.wikipedia.org/wiki/Hamiltonian_matrix) converge to a stationary distribution, which is the Perron projection of the two matrices
 
 ```{code-cell} ipython3
 P = np.array([[0.68, 0.12, 0.20],
@@ -449,7 +449,7 @@ As we have seen, the largest eigenvalue for a primitive stochastic matrix is one
 This can be proven using [Gershgorin Circle Theorem](https://en.wikipedia.org/wiki/Gershgorin_circle_theorem),
 but it is out of the scope of this lecture.
 
-So by the statement (6) of Perron-Frobenius Theorem, $\lambda_i<1$ for all $i<n$, and $\lambda_n=1$ when $P$ is primitive.
+So by the statement (6) of Perron-Frobenius theorem, $\lambda_i<1$ for all $i<n$, and $\lambda_n=1$ when $P$ is primitive.
 
 Hence, after taking the Euclidean norm deviation, we obtain
 

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -45,7 +45,7 @@ In the natural sciences (and in more traditional economics courses), heavy-taile
 
 However, it turns out that heavy-tailed distributions play a crucial role in economics.
 
-In fact many -- if not most -- of the important distributions in economics are heavy tailed.
+In fact many -- if not most -- of the important distributions in economics are heavy-tailed.
 
 In this lecture we explain what heavy tails are and why they are -- or at least
 why they should be -- central to economic analysis.
@@ -828,7 +828,7 @@ plt.show()
 
 ### City size
 
-Here are plots of the city size distribution for the US and Brazil in 2023 from world population review.
+Here are plots of the city size distribution for the US and Brazil in 2023 from the World Population Review.
 
 The size is measured by population.
 
@@ -943,7 +943,7 @@ One impact of heavy tails is that sample averages can be poor estimators of
 the underlying mean of the distribution.
 
 To understand this point better, recall {doc}`our earlier discussion <lln_clt>` 
-of the Law of Large Numbers, which considered IID $X_1, \ldots, X_n$ with common distribution $F$
+of the law of large numbers, which considered IID $X_1, \ldots, X_n$ with common distribution $F$
 
 If $\mathbb E |X_i|$ is finite, then
 the sample mean $\bar X_n := \frac{1}{n} \sum_{i=1}^n X_i$ satisfies
@@ -957,7 +957,7 @@ the sample mean $\bar X_n := \frac{1}{n} \sum_{i=1}^n X_i$ satisfies
 where $\mu := \mathbb E X_i = \int x F(dx)$ is the common mean of the sample.
 
 The condition $\mathbb E | X_i | = \int |x| F(dx) < \infty$ holds
-in most cases but can fail if the distribution $F$ is very heavy tailed.
+in most cases but can fail if the distribution $F$ is very heavy-tailed.
 
 For example, it fails for the Cauchy distribution.
 
@@ -1006,7 +1006,7 @@ We return to this point in the exercises.
 We have now seen that 
 
 1. heavy tails are frequent in economics and
-2. the Law of Large Numbers fails when tails are very heavy.
+2. the law of large numbers fails when tails are very heavy.
 
 But what about in the real world?  Do heavy tails matter?
 
@@ -1261,7 +1261,7 @@ Present discounted value of tax revenue will be estimated by
 
 The Pareto distribution is assumed to take the form {eq}`pareto` with $\bar x = 1$ and $\alpha = 1.05$.
 
-(The value the tail index $\alpha$ is plausible given the data {cite}`gabaix2016power`.)
+(The value of the tail index $\alpha$ is plausible given the data {cite}`gabaix2016power`.)
 
 To make the lognormal option as similar as possible to the Pareto option, choose 
 its parameters such that the mean and median of both distributions are the same.
@@ -1315,7 +1315,7 @@ $$
 
 which we solve for $\mu$ and $\sigma$ given $\alpha = 1.05$.
 
-Here is code that generates the two samples, produces the violin plot and
+Here is the code that generates the two samples, produces the violin plot and
 prints the mean and standard deviation of the two samples.
 
 ```{code-cell} ipython3

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -58,6 +58,9 @@ the natural sciences have "light tails."
 
 To explain this concept, let's look first at examples.
 
+```{prf:example}
+:label: ht_ex_nd
+
 The classic example is the [normal distribution](https://en.wikipedia.org/wiki/Normal_distribution), which has density
 
 $$ 
@@ -73,6 +76,7 @@ respectively.
 
 As $x$ deviates from $\mu$, the value of $f(x)$ goes to zero extremely
 quickly.
+```
 
 We can see this when we plot the density and show a histogram of observations,
 as with the following code (which assumes $\mu=0$ and $\sigma=1$).
@@ -277,6 +281,9 @@ The data we have just seen is said to be "heavy-tailed".
 With heavy-tailed distributions, extreme outcomes occur relatively
 frequently.
 
+```{prf:example}
+:label: ht_ex_od
+
 Importantly, there are many examples of heavy-tailed distributions
 observed in economic and financial settings!
 
@@ -292,6 +299,7 @@ The firm size distribution is also heavy-tailed
 The distribution of town and city sizes is heavy-tailed 
 
 * Most towns and cities are small but some are very large.
+```
 
 Later in this lecture, we examine heavy tails in these distributions.
 

--- a/lectures/inequality.md
+++ b/lectures/inequality.md
@@ -23,6 +23,8 @@ households in a given country.
 
 However, when we study income and wealth, averages are only part of the story.
 
+```{prf:example}
+:label: ie_ex_av
 
 For example, imagine two societies, each with one million people, where
 
@@ -32,6 +34,7 @@ For example, imagine two societies, each with one million people, where
 
 These countries have the same income per capita (average income is $100) but the lives of the people will be very different (e.g., almost everyone in the first society is
 starving, even though one person is fabulously rich).
+```
 
 The example above suggests that we should go beyond simple averages when we study income and wealth.
 

--- a/lectures/inequality.md
+++ b/lectures/inequality.md
@@ -18,15 +18,16 @@ kernelspec:
 In the lecture {doc}`long_run_growth` we studied how GDP per capita has changed
 for certain countries and regions.
 
-Per capital GDP is important because it gives us an idea of average income for
+Per capita GDP is important because it gives us an idea of average income for
 households in a given country.
 
 However, when we study income and wealth, averages are only part of the story.
 
+
 For example, imagine two societies, each with one million people, where
 
 * in the first society, the yearly income of one man is $100,000,000 and the income of the
-  others is zero
+  others are zero
 * in the second society, the yearly income of everyone is $100
 
 These countries have the same income per capita (average income is $100) but the lives of the people will be very different (e.g., almost everyone in the first society is
@@ -532,7 +533,7 @@ Let's look at the Gini coefficient for the distribution of income in the US.
 
 We will get pre-computed Gini coefficients (based on income) from the World Bank using the [wbgapi](https://blogs.worldbank.org/opendata/introducing-wbgapi-new-python-package-accessing-world-bank-data).
 
-Let's use the `wbgapi` package we imported earlier to search the world bank data for Gini to find the Series ID.
+Let's use the `wbgapi` package we imported earlier to search the World Bank data for Gini to find the Series ID.
 
 ```{code-cell} ipython3
 wb.search("gini")
@@ -755,8 +756,9 @@ min_year = plot_data.year.min()
 max_year = plot_data.year.max()
 ```
 
-The time series for all three countries start and stop in different years. We will add a year mask to the data to
-improve clarity in the chart including the different end years associated with each countries time series.
+The time series for all three countries start and stop in different years. 
+
+We will add a year mask to the data to improve clarity in the chart including the different end years associated with each country's time series.
 
 ```{code-cell} ipython3
 labels = [1979, 1986, 1991, 1995, 2000, 2020, 2021, 2022] + \
@@ -783,7 +785,7 @@ fig.show()
 This figure is built using `plotly` and is {ref}` available on the website <fig:plotly-gini-gdppc-years>`
 ```
 
-This plot shows that all three Western economies GDP per capita has grown over
+This plot shows that all three Western economies' GDP per capita has grown over
 time with some fluctuations in the Gini coefficient. 
 
 From the early 80's the United Kingdom and the US economies both saw increases

--- a/lectures/input_output.md
+++ b/lectures/input_output.md
@@ -263,6 +263,8 @@ $$
 $$
 
 
+```{prf:example}
+:label: io_ex_tg
 
 For example a two-good economy described by
 
@@ -290,6 +292,7 @@ d = np.array([50, 2]).reshape((2, 1))
 I = np.identity(2)
 B = I - A
 B
+```
 ```
 
 Let's check the **Hawkins-Simon conditions**
@@ -336,6 +339,9 @@ $$
 
 Equation {eq}`eq:inout_frontier` sweeps out a  **production possibility frontier** of final consumption bundles $d$ that can be produced with exogenous labor input $x_0$.
 
+```{prf:example}
+:label: io_ex_ppf
+
 Consider the example in {eq}`eq:inout_ex`.
 
 Suppose we are now given
@@ -361,6 +367,7 @@ Thus, the production possibility frontier for this economy is
 $$
 10d_1 + 500d_2 = x_0
 $$
+```
 
 +++ {"user_expressions": []}
 

--- a/lectures/input_output.md
+++ b/lectures/input_output.md
@@ -281,6 +281,7 @@ d =
     2
 \end{bmatrix}
 $$ (eq:inout_ex)
+```
 
 ```{code-cell} ipython3
 A = np.array([[0.1, 40],
@@ -292,7 +293,6 @@ d = np.array([50, 2]).reshape((2, 1))
 I = np.identity(2)
 B = I - A
 B
-```
 ```
 
 Let's check the **Hawkins-Simon conditions**
@@ -351,6 +351,7 @@ a_0^\top = \begin{bmatrix}
 4 & 100
 \end{bmatrix}
 $$
+```
 
 Then we can find $A_0^\top$ by
 
@@ -367,7 +368,6 @@ Thus, the production possibility frontier for this economy is
 $$
 10d_1 + 500d_2 = x_0
 $$
-```
 
 +++ {"user_expressions": []}
 

--- a/lectures/input_output.md
+++ b/lectures/input_output.md
@@ -120,7 +120,7 @@ A basic framework for their analysis is
 After  introducing the input-output model, we describe some of its connections to {doc}`linear programming lecture <lp_intro>`.
 
 
-## Input output analysis
+## Input-output analysis
 
 Let
 
@@ -184,7 +184,7 @@ plt.text(1.6, -0.5, r'$d_{2}$')
 plt.show()
 ```
 
-**Feasible allocations must satisfy**
+*Feasible allocations must satisfy*
 
 $$
 \begin{aligned}
@@ -264,7 +264,7 @@ $$
 
 
 
-For example a two good economy described by
+For example a two-good economy described by
 
 $$
 A =
@@ -507,9 +507,9 @@ This illustrates that an element $l_{ij}$ of $L$ shows the total impact on secto
 
 ## Applications of graph theory
 
-We can further study input output networks through applications of {doc}`graph theory <networks>`.
+We can further study input-output networks through applications of {doc}`graph theory <networks>`.
 
-An input output network can be represented by a weighted directed graph induced by the adjacency matrix $A$.
+An input-output network can be represented by a weighted directed graph induced by the adjacency matrix $A$.
 
 The set of nodes $V = [n]$ is the list of sectors and the set of edges is given by
 
@@ -550,7 +550,7 @@ The above figure indicates that manufacturing is the most dominant sector in the
 
 ### Output multipliers
 
-Another way to rank sectors in input output networks is via output multipliers.
+Another way to rank sectors in input-output networks is via output multipliers.
 
 The **output multiplier** of sector $j$ denoted by $\mu_j$ is usually defined as the
 total sector-wide impact of a unit change of demand in sector $j$.


### PR DESCRIPTION
Dear John @jstac and Matt @mmcky ,

This pull request is to check the example admonition and spelling of from lecture [ar1_processes.md] to [eigen_II.md] according to #520 and #532.  

The details are shown below:

- ar1_processes.md
   - add two example admonitions
- business_cycle.md (no typos, no example admonition)
- cagan_adaptive.md (no typos, no example admonition)
- cagan_ree.md
   - change 'a central banks's' to 'a central bank's'
   - change 'fisal' to 'fiscal'
   - change " to start a persistent inflation the government 'beings' " to  'begins'
- cobweb.md (no typos, no example admonition)
- commod_price.md (no typos, no example admonition)
- complex_and_trig.md
   - add one example admonition
- cons_smooth.md
   - change 'consumption smoothing model' to 'consumption-smoothing model' for consistency
   - change 'first order' to 'first-order' for consistency
   - change 'finanical' to 'financial'
   - change 'accross' to 'across'
   - change 'enlighening' to 'enlightening'
   - change the Capitalized title to match the style guide
   - change 'create a function that generate' to 'create a function that generates'
 - eigen_I.md
   - add one example admonition
 - eigen_II.md
   - change the subtitle to lower case to match the style guide
   - change 'Perron-Frobenius Theorem' to 'Perron-Frobenius theorem' for consistency (used in the current subtitles and also in wikipedia)
   - add example admonition
 - heavy_tails.md
   - change 'from world population review' to 'from the World Population Review'
   - change 'Law of Large Numbers' to 'law of large numbers' to match with Wikipedia form as discussed before
   - change 'heavy tailed' to 'heavy-tailed' for consistency
   - change 'The value the tail index' to 'The value of the tail index'
   - change 'Here is code that generates' to 'Here is the code generates'
   - add two example admonitions
- inequality.md
  - change 'per capital' to 'per capita'
  - change 'others is zero' to 'others are zero'
  - change 'the world bank' to 'the World Bank' to match Wikipedia 
  - add empty link to match with the style guide
  - change 'Western economies GDP' to 'Western economies'GDP'
  - add one example admonition
- input_output.md
  - change 'input output' to 'input-output' for consistency
  - change **feasible allocations must satisfy**  to *feasible allocations must satisfy* to match with style guide
  - change 'a two good economy' to 'a two-good economy'  
  - add two example admonitions containing code blocks.

Best ❤️ 
Longye