### PR TITLE
[markov_chains_II] to [money_inflation]spelling and example admontion

### DIFF
--- a/lectures/markov_chains_II.md
+++ b/lectures/markov_chains_II.md
@@ -392,7 +392,7 @@ plt.show()
 ````{exercise}
 :label: mc_ex1
 
-Benhabib el al. {cite}`benhabib_wealth_2019` estimated that the transition matrix for social mobility as the following
+Benhabib et al. {cite}`benhabib_wealth_2019` estimated that the transition matrix for social mobility as the following
 
 $$
 P:=

--- a/lectures/markov_chains_II.md
+++ b/lectures/markov_chains_II.md
@@ -107,6 +107,9 @@ mc = qe.MarkovChain(P, ('poor', 'middle', 'rich'))
 mc.is_irreducible
 ```
 
+```{prf:example}
+:label: mc2_ex_pf
+
 Here's a more pessimistic scenario in which  poor people remain poor forever
 
 ```{image} /_static/lecture_specific/markov_chains_II/Irre_2.png
@@ -116,6 +119,7 @@ Here's a more pessimistic scenario in which  poor people remain poor forever
 
 This stochastic matrix is not irreducible since, for example, rich is not
 accessible from poor.
+```
 
 Let's confirm this
 
@@ -272,6 +276,9 @@ In any of these cases, ergodicity will hold.
 
 ### Example: a periodic chain
 
+```{prf:example}
+:label: mc2_ex_pc
+
 Let's look at the following example with states 0 and 1:
 
 $$
@@ -291,7 +298,7 @@ The transition graph shows that this model is irreducible.
 ```
 
 Notice that there is a periodic cycle --- the state cycles between the two states in a regular way.
-
+```
 Not surprisingly, this property 
 is called [periodicity](https://stats.libretexts.org/Bookshelves/Probability_Theory/Probability_Mathematical_Statistics_and_Stochastic_Processes_(Siegrist)/16%3A_Markov_Processes/16.05%3A_Periodicity_of_Discrete-Time_Chains).
 

--- a/lectures/markov_chains_II.md
+++ b/lectures/markov_chains_II.md
@@ -71,6 +71,8 @@ that
 The stochastic matrix $P$ is called **irreducible** if all states communicate;
 that is, if $x$ and $y$ communicate for all $(x, y)$ in $S \times S$.
 
+```{prf:example}
+:label: mc2_ex_ir
 For example, consider the following transition probabilities for wealth of a
 fictitious set of households
 
@@ -95,6 +97,7 @@ $$
 
 It's clear from the graph that this stochastic matrix is irreducible: we can  eventually
 reach any state from any other state.
+```
 
 We can also test this using [QuantEcon.py](http://quantecon.org/quantecon-py)'s MarkovChain class
 

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -39,6 +39,8 @@ $$
 
 where $w$ is wealth.
 
+```{prf:example}
+:label: mle_ex_wt
 
 For example, if $a = 0.05$, $b = 0.1$, and $\bar w = 2.5$, this means 
 
@@ -46,7 +48,7 @@ For example, if $a = 0.05$, $b = 0.1$, and $\bar w = 2.5$, this means
 * a 10% tax on wealth in excess of 2.5.
 
 The unit is 100,000, so $w= 2.5$ means 250,000 dollars.
-
+```
 Let's go ahead and define $h$:
 
 ```{code-cell} ipython3
@@ -242,7 +244,7 @@ num = (ln_sample - μ_hat)**2
 σ_hat
 ```
 
-Let's plot the log-normal pdf using the estimated parameters against our sample data.
+Let's plot the lognormal pdf using the estimated parameters against our sample data.
 
 ```{code-cell} ipython3
 dist_lognorm = lognorm(σ_hat, scale = exp(μ_hat))

--- a/lectures/money_inflation.md
+++ b/lectures/money_inflation.md
@@ -35,7 +35,7 @@ Our model equates the demand for money to the supply at each time $t \geq 0$.
 Equality between those demands and supply gives a *dynamic* model in which   money supply
 and  price level *sequences* are simultaneously determined by a  set of simultaneous linear  equations.
 
-These equations take the form of what are often called vector linear **difference equations**.  
+These equations take the form of what is often called vector linear **difference equations**.  
 
 In this lecture, we'll roll up our sleeves and solve those equations in two different ways.
 
@@ -49,19 +49,19 @@ In this lecture we will encounter these concepts from macroeconomics:
 * perverse dynamics under rational expectations in which the system converges to the higher stationary inflation tax rate
 * a peculiar comparative stationary-state outcome connected with that stationary inflation rate: it asserts that inflation can be *reduced* by running *higher*  government deficits, i.e., by raising more resources by printing money. 
 
-The same qualitive outcomes prevail in this lecture {doc}`money_inflation_nonlinear` that studies a nonlinear version of the model in this lecture.  
+The same qualitative outcomes prevail in this lecture {doc}`money_inflation_nonlinear` that studies a nonlinear version of the model in this lecture.  
 
 These outcomes  set the stage for the analysis to be presented in this lecture {doc}`laffer_adaptive` that studies a nonlinear version of the present model; it   assumes a version of "adaptive expectations" instead of rational expectations.
 
 That lecture will show that 
 
 * replacing rational expectations with adaptive expectations leaves the two stationary inflation rates unchanged, but that $\ldots$ 
-* it reverse the pervese dynamics by making the *lower* stationary inflation rate the one to which the system typically converges
+* it reverses the perverse dynamics by making the *lower* stationary inflation rate the one to which the system typically converges
 * a more plausible comparative dynamic outcome emerges in which now inflation can be *reduced* by running *lower*  government deficits
 
-This outcome will be used to justify a selection of a stationary inflation rate that underlies the analysis of unpleasant monetarist arithmetic to be studies in this lecture {doc}`unpleasant`.
+This outcome will be used to justify a selection of a stationary inflation rate that underlies the analysis of unpleasant monetarist arithmetic to be studied in this lecture {doc}`unpleasant`.
 
-We'll use theses tools from linear algebra:
+We'll use these tools from linear algebra:
 
 * matrix multiplication
 * matrix inversion
@@ -349,7 +349,7 @@ g2 = seign(msm.R_l, msm)
 print(f'R_l, g_l = {msm.R_l:.4f}, {g2:.4f}')
 ```
 
-Now let's compute the maximum steady-state amount of seigniorage that could be gathered by printing money and the state state rate of return on money that attains it.
+Now let's compute the maximum steady-state amount of seigniorage that could be gathered by printing money and the state-state rate of return on money that attains it.
 
 ## Two  computation strategies
 
@@ -950,7 +950,7 @@ Those dynamics are "perverse" not only in the sense that they imply that the mon
 
 
 ```{note}
-The same qualitive outcomes prevail in this lecture {doc}`money_inflation_nonlinear` that studies a nonlinear version of the model in this lecture.
+The same qualitative outcomes prevail in this lecture {doc}`money_inflation_nonlinear` that studies a nonlinear version of the model in this lecture.
 ```
 
 

--- a/lectures/money_inflation_nonlinear.md
+++ b/lectures/money_inflation_nonlinear.md
@@ -35,14 +35,14 @@ As in that  lecture,  we discussed these topics:
 * an **inflation tax** that a government gathers by printing paper or electronic money
 * a dynamic **Laffer curve** in the inflation tax rate that has two stationary equilibria
 * perverse dynamics under rational expectations in which the system converges to the higher stationary inflation tax rate
-* a peculiar comparative stationary-state analysis connected with that stationary inflation rate that assert that inflation can be *reduced* by running *higher*  government deficits 
+* a peculiar comparative stationary-state analysis connected with that stationary inflation rate that asserts that inflation can be *reduced* by running *higher*  government deficits 
 
 These outcomes will set the stage for the analysis of {doc}`laffer_adaptive` that studies a version of the present model that  uses a version of "adaptive expectations" instead of rational expectations.
 
 That lecture will show that 
 
 * replacing rational expectations with adaptive expectations leaves the two stationary inflation rates unchanged, but that $\ldots$ 
-* it reverse the pervese dynamics by making the *lower* stationary inflation rate the one to which the system typically converges
+* it reverses the perverse dynamics by making the *lower* stationary inflation rate the one to which the system typically converges
 * a more plausible comparative dynamic outcome emerges in which now inflation can be *reduced* by running *lower*  government deficits
 
 ## The model
@@ -399,7 +399,7 @@ Those dynamics are "perverse" not only in the sense that they imply that the mon
 * the figure indicates that inflation can be *reduced* by running *higher*  government deficits, i.e., by raising more resources through  printing money. 
 
 ```{note}
-The same qualitive outcomes prevail in {doc}`money_inflation` that studies a linear version of the model in this lecture.
+The same qualitative outcomes prevail in {doc}`money_inflation` that studies a linear version of the model in this lecture.
 ```
 
 We discovered that 


### PR DESCRIPTION
This pull request is to update spelling #532  and example admonitions #520 for the following lectures. More specifically:

[markov_chains_II.md]
- change 'Benhabib el al' to 'Benhabib et al'
- add three example admonitions

[mle.md]
- change 'log-normal' to 'lognormal' for consistency
- add one example admonition.

[money_inflation_nonlinear.md]

- change 'stationary inflation rate that assert' to 'stationary inflation rate that asserts'
- change 'it reverse the pervese' to 'it reverses the perverse'
- change 'qualitive' to 'qualitative'. 
- no example admonition is needed.

[money_inflation.md]
- change 'take the form of what are' to 'take the form of what is'
- change 'qualitive outcome' to 'qualitative outcome'
- change 'it reverse the pervese' to 'it reverses the perverse'
- change 'theses tools' to 'these tools'
- change 'steady state rate' to 'steady-state rate' for consistency
- Checked and no need to add example admonitions. 

