### PR TITLE
ENH: remove binder and default to colab

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -70,8 +70,6 @@ sphinx:
       analytics:
         google_analytics_id: G-QDS1YRJNGM
       launch_buttons:
-        notebook_interface        : classic  # The interface interactive links will activate ["classic", "jupyterlab"]
-        binderhub_url             : https://mybinder.org  # The URL of the BinderHub (e.g., https://mybinder.org)
         colab_url                 : https://colab.research.google.com
         thebe                     : false  # Add a thebe button to pages (requires the repository to run on Binder)
     intersphinx_mapping:


### PR DESCRIPTION
This PR removes `mybinder` link and defaults to Google collab. 