### PR TITLE
Change to `np.NAN` --> `np.nan`

### DIFF
--- a/lectures/money_inflation.md
+++ b/lectures/money_inflation.md
@@ -901,7 +901,7 @@ def draw_iterations(p0s, model, line_params, num_steps):
         axes[1].plot(time_steps, P, **line_params)
         
         # Calculate R_t
-        R = np.insert(P[:-1] / P[1:], 0, np.NAN)
+        R = np.insert(P[:-1] / P[1:], 0, np.nan)
         axes[2].plot(time_steps, R, **line_params)
         
     # Add line and text annotations to the subgraph 


### PR DESCRIPTION
This is deprecated and removed fully in numpy 2.0.

Please see:
https://numpy.org/doc/1.26/reference/constants.html#numpy.NAN