### PR TITLE
[WASM][long_run_growth] Update data url for fetching the dataset

### DIFF
--- a/lectures/long_run_growth.md
+++ b/lectures/long_run_growth.md
@@ -94,7 +94,7 @@ Here we read the Maddison data into a pandas `DataFrame`:
 
 ```{code-cell} ipython3
 pyodide_http.patch_all()
-data_url = "https://github.com/QuantEcon/lecture-python-intro/raw/main/lectures/datasets/mpd2020.xlsx"
+data_url = "https://raw.githubusercontent.com/QuantEcon/lecture-python-intro/main/lectures/datasets/mpd2020.xlsx"
 data = pd.read_excel(data_url, 
                      sheet_name='Full data')
 data.head()


### PR DESCRIPTION
Use `raw.githubusercontent.com` domain for fetching the datasets which is wasm compatible.

Fixes: https://github.com/kp992/intro-wasm-demo/issues/1

cc @mmcky 