### PR TITLE
Fix definition of primitive matrix and clarify Hamilton matrix reference

### DIFF
--- a/lectures/eigen_II.md
+++ b/lectures/eigen_II.md
@@ -238,7 +238,7 @@ A = \begin{bmatrix} 0.5 & 0.1 \\
 \end{bmatrix}
 $$
 
-A here is also a primitive matrix since $A^k$ is everywhere positive for some $k \in \mathbb{N}$.
+$A$ here is also a primitive matrix since $A^k$ is everywhere positive for some $k \in \mathbb{N}$.
 
 
 $$
@@ -393,7 +393,7 @@ We are now prepared to bridge the languages spoken in the two lectures.
 
 A primitive matrix is both irreducible and aperiodic.
 
-So the Perron-Frobenius theorem explains why both the Imam and Temple matrix and Hamilton’s transition matrix (`mc_eg2`) converge to a stationary distribution — the Perron projection of the two matrices.
+So Perron-Frobenius theorem explains why both {ref}`Imam and Temple matrix <mc_eg3>` and {ref}`Hamilton matrix <mc_eg2>` converge to a stationary distribution, which is the Perron projection of the two matrices
 
 
 ```{code-cell} ipython3

--- a/lectures/eigen_II.md
+++ b/lectures/eigen_II.md
@@ -240,7 +240,6 @@ $$
 
 $A$ here is also a primitive matrix since $A^k$ is everywhere positive for some $k \in \mathbb{N}$.
 
-
 $$
 B = \begin{bmatrix} 0 & 1 \\ 
                     1 & 0 
@@ -394,7 +393,6 @@ We are now prepared to bridge the languages spoken in the two lectures.
 A primitive matrix is both irreducible and aperiodic.
 
 So Perron-Frobenius theorem explains why both {ref}`Imam and Temple matrix <mc_eg3>` and {ref}`Hamilton matrix <mc_eg2>` converge to a stationary distribution, which is the Perron projection of the two matrices
-
 
 ```{code-cell} ipython3
 P = np.array([[0.68, 0.12, 0.20],

--- a/lectures/eigen_II.md
+++ b/lectures/eigen_II.md
@@ -238,7 +238,8 @@ A = \begin{bmatrix} 0.5 & 0.1 \\
 \end{bmatrix}
 $$
 
-$A$ here is also a primitive matrix since $A^k$ is everywhere nonnegative for $k \in \mathbb{N}$.
+A here is also a primitive matrix since $A^k$ is everywhere positive for some $k \in \mathbb{N}$.
+
 
 $$
 B = \begin{bmatrix} 0 & 1 \\ 
@@ -392,7 +393,8 @@ We are now prepared to bridge the languages spoken in the two lectures.
 
 A primitive matrix is both irreducible and aperiodic.
 
-So Perron-Frobenius theorem explains why both {ref}`Imam and Temple matrix <mc_eg3>` and [Hamilton matrix](https://en.wikipedia.org/wiki/Hamiltonian_matrix) converge to a stationary distribution, which is the Perron projection of the two matrices
+So the Perron-Frobenius theorem explains why both the Imam and Temple matrix and Hamilton’s transition matrix (`mc_eg2`) converge to a stationary distribution — the Perron projection of the two matrices.
+
 
 ```{code-cell} ipython3
 P = np.array([[0.68, 0.12, 0.20],


### PR DESCRIPTION
This PR fixes two minor issues referenced in #576:

1. Primitive matrix definition : Updated the condition to say $A^k$ is *positive* for some $k \in \mathbb{N}$, which is the correct definition of a primitive matrix.

2. Hamilton matrix: Replaced the misleading term "Hamilton matrix" with "Hamilton’s transition matrix (`mc_eg2`)" to avoid confusion with Hamiltonian matrices in physics.

I hope this fix was helpful, Happy to make any changes if needed — just let me know.
