### PR TITLE
[WASM][lln_clt]Reduce the array size in wasm

### DIFF
--- a/lectures/lln_clt.md
+++ b/lectures/lln_clt.md
@@ -472,8 +472,8 @@ $F(x) = 1 - e^{- \lambda x}$.
 
 ```{code-cell} ipython3
 # Set parameters
-n = 250         # Choice of n
-k = 1_000_000        # Number of draws of Y_n
+n = 50         # Choice of n
+k = 10_000        # Number of draws of Y_n
 distribution = st.expon(2) # Exponential distribution, λ = 1/2
 μ, σ = distribution.mean(), distribution.std()
 
@@ -523,8 +523,8 @@ You can choose any $\alpha > 0$ and $\beta > 0$.
 
 ```{code-cell} ipython3
 # Set parameters
-n = 250         # Choice of n
-k = 1_000_000        # Number of draws of Y_n
+n = 50         # Choice of n
+k = 10_000        # Number of draws of Y_n
 distribution = st.beta(2,2) # We chose Beta(2, 2) as an example
 μ, σ = distribution.mean(), distribution.std()
 


### PR DESCRIPTION
Fixes the memory error in WASM environment:
```
MemoryError: Unable to allocate 1.86 GiB for an array with shape (1000000, 250) and data type float 64
```

Fixes https://github.com/kp992/intro-wasm-demo/issues/7