### PR TITLE
MAINT: enable dependabot checking of conda environment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
       prefix: ⬆️
     schedule:
       interval: weekly
+  - package-ecosystem: "conda"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR enables Dependabot checking of the `conda` ecosystem