### PR TITLE
MAINT: enable beta for dependabot support for anaconda

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
       prefix: ⬆️
     schedule:
       interval: weekly
+  - package-ecosystem: "conda"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Currently `conda` needs `beta` features enabled. 