### PR TITLE
Update _config.yml for quantecon-book-theme upgrade

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.15.0
+    - quantecon-book-theme==0.15.1
     - sphinx-tojupyter==0.3.1
     - sphinxext-rediraffe==0.3.0
     - sphinx-exercise==1.0.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -79,8 +79,6 @@ sphinx:
     suppress_warnings: [mystnb.unknown_mime_type, myst.domains]
     # sphinx-proof
     proof_minimal_theme: true
-    # sphinx-exercise
-    exercise_style: "solution_follow_exercise"
     # -------------
     html_js_files:
       - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -44,8 +44,43 @@ sphinx:
     nb_render_image_options:
       width: 80%
     nb_code_prompt_show: "Show {type}"
+    nb_merge_streams: true
+    nb_mime_priority_overrides: [
+       # HTML
+       ['html', 'application/vnd.jupyter.widget-view+json', 10],
+       ['html', 'application/javascript', 20],
+       ['html', 'text/html', 30],
+       ['html', 'text/latex', 40],
+       ['html', 'image/svg+xml', 50],
+       ['html', 'image/png', 60],
+       ['html', 'image/jpeg', 70],
+       ['html', 'text/markdown', 80],
+       ['html', 'text/plain', 90],
+       # Jupyter Notebooks
+       ['jupyter', 'application/vnd.jupyter.widget-view+json', 10],
+       ['jupyter', 'application/javascript', 20],
+       ['jupyter', 'text/html', 30],
+       ['jupyter', 'text/latex', 40],
+       ['jupyter', 'image/svg+xml', 50],
+       ['jupyter', 'image/png', 60],
+       ['jupyter', 'image/jpeg', 70],
+       ['jupyter', 'text/markdown', 80],
+       ['jupyter', 'text/plain', 90],
+       # LaTeX
+       ['latex', 'text/latex', 10],
+       ['latex', 'application/pdf', 20],
+       ['latex', 'image/png', 30],
+       ['latex', 'image/jpeg', 40],
+       ['latex', 'text/markdown', 50],
+       ['latex', 'text/plain', 60],
+       # Link Checker
+       ['linkcheck', 'text/plain', 10],
+     ]
     suppress_warnings: [mystnb.unknown_mime_type, myst.domains]
+    # sphinx-proof
     proof_minimal_theme: true
+    # sphinx-exercise
+    exercise_style: "solution_follow_exercise"
     # -------------
     html_js_files:
       - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
@@ -63,6 +98,7 @@ sphinx:
       header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-python-intro
       nb_repository_url: https://github.com/QuantEcon/lecture-python-intro.notebooks
+      path_to_docs: lectures
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png


### PR DESCRIPTION
## Summary

Updates `_config.yml` and `environment.yml` to align with the latest quantecon-book-theme (0.15.1), cross-referenced with [lecture-python.myst](https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/_config.yml).

## Changes

### environment.yml
- **`quantecon-book-theme==0.15.1`** - Upgrade from 0.15.0 to include fix for `path_to_docs` stripping in notebook launch URLs

### _config.yml
- **`path_to_docs: lectures`** - Added to `html_theme_options` for proper repository link construction and correct Colab/JupyterHub/Binder URLs
- **`nb_merge_streams: true`** - Merges stdout/stderr in notebook outputs
- **`nb_mime_priority_overrides`** - Configures MIME type priorities for HTML, Jupyter, LaTeX, and linkcheck outputs (important for Jupyter widget support)

## Reference

- Configuration aligned with: https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/_config.yml
- Theme changelog: https://github.com/QuantEcon/quantecon-book-theme/blob/main/CHANGELOG.md\#0151---2025-12-11

## Notes

- Removed `exercise_style` config as it's not supported by sphinx-exercise 1.0.1 (used in this repo)