### PR TITLE
⬆️ Configure dependabot to ignore Python version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,12 @@ updates:
       interval: weekly
   - package-ecosystem: "conda"
     directory: "/"
+    commit-message:
+      prefix: ⬆️
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "jupyter-book"
+        versions: [">=2.0"]
+      - dependency-name: "python"
+        # Python version should be constrained by the anaconda distribution version


### PR DESCRIPTION
Python version should be constrained by the anaconda distribution version specified in environment.yml, not updated independently by dependabot.

This prevents dependabot from opening PRs like #685 that attempt to update the Python version independently of the anaconda distribution.