### PR TITLE
Fix grammar and spelling errors across lecture files

### DIFF
--- a/lectures/ar1_processes.md
+++ b/lectures/ar1_processes.md
@@ -356,7 +356,7 @@ In this equation, we can use observed data to evaluate the left hand side of {eq
 
 And we can use a theoretical AR(1) model to calculate the right hand side.
 
-If $\frac{1}{m} \sum_{t = 1}^m X_t$ is not close to $\psi^(x)$, even for many
+If $\frac{1}{m} \sum_{t = 1}^m X_t$ is not close to $\psi^*(x)$, even for many
 observations, then our theory seems to be incorrect and we will need to revise
 it.
 

--- a/lectures/business_cycle.md
+++ b/lectures/business_cycle.md
@@ -211,7 +211,7 @@ plt.show()
 
 GDP growth is positive on average and trending slightly downward over time.
 
-We also see fluctuations over GDP growth over time, some of which are quite large.
+We also see fluctuations in GDP growth over time, some of which are quite large.
 
 Let's look at a few more countries to get a basis for comparison.
 
@@ -608,7 +608,7 @@ perspectives: consumption, production, and credit level.
 
 ### Consumption
 
-Consumption depends on consumers' confidence towards their
+Consumption depends on consumers' confidence in their
 income and the overall performance of the economy in the future. 
 
 One widely cited indicator for consumer confidence is the [consumer sentiment index](https://fred.stlouisfed.org/series/UMCSENT) published by the University

--- a/lectures/cagan_adaptive.md
+++ b/lectures/cagan_adaptive.md
@@ -437,8 +437,8 @@ We invite you to explain to  yourself the source of this overshooting and why it
 
 ### Experiment 2
 
-Now we'll do a different experiment, namely, a gradual stabilization in which the rate of growth of the money supply smoothly 
-decline from a high value to a persistently low value.  
+Now we'll do a different experiment, namely, a gradual stabilization in which the rate of growth of the money supply smoothly
+declines from a high value to a persistently low value.  
 
 While price level inflation eventually falls, it falls more slowly than the driving  force that ultimately causes it to fall, namely, the falling rate of growth of the money supply.
 

--- a/lectures/long_run_growth.md
+++ b/lectures/long_run_growth.md
@@ -57,7 +57,7 @@ These graphs will portray how the "Industrial Revolution" began in Britain in th
 
 In a nutshell, this lecture records growth trajectories of various countries over long time periods. 
 
-While some countries have experienced long-term rapid growth across that has lasted a hundred years, others have not. 
+While some countries have experienced long-term rapid growth that has lasted a hundred years, others have not. 
 
 Since populations differ across countries and vary within a country over time, it will
 be interesting to describe both total GDP and GDP per capita as it evolves within a country.
@@ -181,7 +181,7 @@ gdp_pc[country].plot(
 [International dollars](https://en.wikipedia.org/wiki/international_dollar) are a hypothetical unit of currency that has the same purchasing power parity that the U.S. Dollar has in the United States at a given point in time. They are also known as Geary–Khamis dollars (GK Dollars).
 :::
 
-We can see that the data is non-continuous for longer periods in the early 250 years of this millennium, so we could choose to interpolate to get a continuous line plot.
+We can see that the data is incomplete for longer periods in the early 250 years of this millennium, so we could choose to interpolate to get a continuous line plot.
 
 Here we use dashed lines to indicate interpolated trends
 

--- a/lectures/lp_intro.md
+++ b/lectures/lp_intro.md
@@ -34,7 +34,7 @@ Linear programs come in pairs:
 
 If a primal problem involves *maximization*, the dual problem involves *minimization*.
 
-If a primal problem involves  *minimization**, the dual problem involves **maximization*.
+If a primal problem involves *minimization*, the dual problem involves *maximization*.
 
 We provide a standard form of a linear program and methods to transform other forms of linear programming problems  into a standard form.
 

--- a/lectures/supply_demand_heterogeneity.md
+++ b/lectures/supply_demand_heterogeneity.md
@@ -36,7 +36,7 @@ import numpy as np
 from scipy.linalg import inv
 ```
 
-## An simple example
+## A simple example
 
 Let's study a simple example of **pure exchange** economy without production.
 

--- a/lectures/tax_smooth.md
+++ b/lectures/tax_smooth.md
@@ -19,7 +19,7 @@ kernelspec:
 This  is a sister lecture to our  lecture on {doc}`consumption-smoothing <cons_smooth>`.
 
 
-By renaming variables, we  obtain  a  version of a model "tax-smoothing model" that  Robert Barro {cite}`Barro1979` used  to explain why governments sometimes choose not to balance their budgets every period but instead use issue debt to smooth tax rates over time.
+By renaming variables, we  obtain  a  version of a model "tax-smoothing model" that  Robert Barro {cite}`Barro1979` used  to explain why governments sometimes choose not to balance their budgets every period but instead issue debt to smooth tax rates over time.
 
 The government chooses a tax collection path that minimizes the present value of its costs of raising revenue.
 
@@ -49,7 +49,7 @@ from collections import namedtuple
 
 A government exists at times $t=0, 1, \ldots, S$ and  faces an exogenous stream of expenditures $\{G_t\}_{t=0}^S$.
 
-It chooses  chooses a stream of tax collections $\{T_t\}_{t=0}^S$.
+It chooses a stream of tax collections $\{T_t\}_{t=0}^S$.
 
 The model takes a government expenditure stream as an "exogenous" input that is somehow determined  outside the model.
 

--- a/lectures/unpleasant.md
+++ b/lectures/unpleasant.md
@@ -36,7 +36,7 @@ by printing money at times $t \geq T$.
 
 These outcomes are the essential finding of Sargent and Wallace's "unpleasant monetarist arithmetic" {cite}`sargent1981`.
 
-That lecture  described  supplies and demands for money that appear in lecture.
+That lecture  described  supplies and demands for money that appear in that lecture.
 
 It also   characterized the steady state equilibrium from which we work backwards in this lecture. 
 


### PR DESCRIPTION
## Summary
- Fixed 10 grammar and spelling errors across 8 lecture markdown files
- Corrected article usage, subject-verb agreement, preposition usage, and word duplications
- Improved word choice for clarity
- Fixed markdown formatting issues

## Files Changed
- **ar1_processes.md**: Fixed missing asterisk in math notation ($\psi^*(x)$)
- **business_cycle.md**: Fixed preposition usage ("fluctuations in GDP" and "confidence in their")
- **cagan_adaptive.md**: Fixed subject-verb agreement ("smoothly declines")
- **long_run_growth.md**: Removed redundant "across" and changed "non-continuous" to "incomplete"
- **lp_intro.md**: Fixed markdown formatting for italics
- **supply_demand_heterogeneity.md**: Fixed article usage ("A simple example")
- **tax_smooth.md**: Removed duplicate "chooses" and extra "use"
- **unpleasant.md**: Clarified pronoun reference ("that lecture")

## Test plan
- [ ] Review each changed file to verify corrections maintain intended meaning
- [ ] Build documentation to ensure no formatting issues introduced
- [ ] Verify all mathematical notation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)