### PR TITLE
UPD: update quantecon-book-theme to v0.20.2 and enable language switcher for zh-cn

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.20.0
+    - quantecon-book-theme==0.20.2
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.3.0
     - sphinx-exercise==1.2.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -100,10 +100,10 @@ sphinx:
       languages:
         - code: en
           name: English
-          url: https://intro.quantecon.org
+          url: https://intro.quantecon.org/
         - code: zh-cn
           name: 中文
-          url: https://quantecon.github.io/lecture-intro.zh-cn
+          url: https://quantecon.github.io/lecture-intro.zh-cn/
       current_language: en
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -97,6 +97,14 @@ sphinx:
       repository_url: https://github.com/QuantEcon/lecture-python-intro
       nb_repository_url: https://github.com/QuantEcon/lecture-python-intro.notebooks
       path_to_docs: lectures
+      languages:
+        - code: en
+          name: English
+          url: https://intro.quantecon.org
+        - code: zh-cn
+          name: 中文
+          url: https://quantecon.github.io/lecture-intro.zh-cn
+      current_language: en
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png


### PR DESCRIPTION
## Changes

- Update `quantecon-book-theme` from `0.20.0` to `0.20.2`
- Enable the language switcher in `html_theme_options` with:
  - **English** (current): https://intro.quantecon.org
  - **中文 (zh-cn)**: https://quantecon.github.io/lecture-intro.zh-cn

### Theme Release Notes

- [v0.20.2](https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.20.2): Fix emphasis color on textual citation "et al." text
- [v0.20.1](https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.20.1): Previous fixes