### PR TITLE
UPD: align collab workflow pinned versions with environment.yml

### DIFF
--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Build Software
         shell: bash -l {0}
         run: |
-          pip install jupyter-book==0.15.1 docutils==0.17.1 quantecon-book-theme==0.7.2 sphinx-tojupyter==0.3.0 sphinxext-rediraffe==0.2.7 sphinx-exercise==0.4.1 sphinxcontrib-youtube==1.1.0 sphinx-togglebutton==0.3.1 arviz==0.13.0 sphinx_proof==0.2.0 sphinx_reredirects==0.1.3
+          pip install jupyter-book==1.0.4post1 quantecon-book-theme==0.20.2 sphinx-tojupyter==0.6.0 sphinxext-rediraffe==0.3.0 sphinx-exercise==1.2.1 sphinxcontrib-youtube==1.4.1 sphinx-togglebutton==0.4.5 sphinx_proof==0.4.0 sphinx_reredirects==1.1.0
       # Build of HTML (Execution Testing)
       - name: Build HTML
         shell: bash -l {0}


### PR DESCRIPTION
## Changes

Aligns the pinned package versions in `.github/workflows/collab.yml` with `environment.yml`.

### Before (collab.yml)
```
jupyter-book==0.15.1 docutils==0.17.1 quantecon-book-theme==0.7.2 sphinx-tojupyter==0.3.0 sphinxext-rediraffe==0.2.7 sphinx-exercise==0.4.1 sphinxcontrib-youtube==1.1.0 sphinx-togglebutton==0.3.1 arviz==0.13.0 sphinx_proof==0.2.0 sphinx_reredirects==0.1.3
```

### After (matches environment.yml)
```
jupyter-book==1.0.4post1 quantecon-book-theme==0.20.2 sphinx-tojupyter==0.6.0 sphinxext-rediraffe==0.3.0 sphinx-exercise==1.2.1 sphinxcontrib-youtube==1.4.1 sphinx-togglebutton==0.4.5 sphinx_proof==0.4.0 sphinx_reredirects==1.1.0
```

Removed `docutils==0.17.1` and `arviz==0.13.0` as they are not pinned in `environment.yml` and the explicit pins were only needed for the older jupyter-book.