### PR TITLE
ci: add sync-translations workflow for zh-cn

### DIFF
--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -17,13 +17,40 @@ jobs:
   sync:
     if: >
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '\translate-resync') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
     runs-on: ubuntu-latest
 
     steps:
+      - name: Resolve merged PR commit for re-sync
+        if: github.event_name == 'issue_comment'
+        id: resolve_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_json="$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})"
+          merged="$(jq -r '.merged' <<<"$pr_json")"
+          merge_commit_sha="$(jq -r '.merge_commit_sha // empty' <<<"$pr_json")"
+
+          if [ "$merged" != "true" ] || [ -z "$merge_commit_sha" ]; then
+            echo "The referenced pull request is not merged or has no merge commit SHA."
+            exit 1
+          fi
+
+          echo "merge_commit_sha=$merge_commit_sha" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2
+          ref: ${{ steps.resolve_pr.outputs.merge_commit_sha || github.sha }}
 
       - uses: QuantEcon/action-translation@v0.14.1
         with:

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -1,0 +1,36 @@
+# Sync Translations — Simplified Chinese
+# On merged PR, translate changed lectures into the zh-cn target repo.
+#
+# Comment \translate-resync on a merged PR to re-trigger sync.
+name: Sync Translations (Simplified Chinese)
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'lectures/**/*.md'
+      - 'lectures/_toc.yml'
+  issue_comment:
+    types: [created]
+
+jobs:
+  sync:
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - uses: QuantEcon/action-translation@v0.14.1
+        with:
+          mode: sync
+          target-repo: QuantEcon/lecture-intro.zh-cn
+          target-language: zh-cn
+          source-language: en
+          docs-folder: lectures
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically translates changed lectures into Simplified Chinese on merged PRs, targeting [QuantEcon/lecture-intro.zh-cn](https://github.com/QuantEcon/lecture-intro.zh-cn) via `QuantEcon/action-translation@v0.14.1`.

## Details

- **Trigger**: On merged PRs that modify `lectures/**/*.md` or `lectures/_toc.yml`
- **Re-trigger**: Comment `\translate-resync` on a merged PR
- **Target repo**: `QuantEcon/lecture-intro.zh-cn`
- **Action**: `QuantEcon/action-translation@v0.14.1`

Based on the same pattern used in [lecture-python-programming](https://github.com/QuantEcon/lecture-python-programming/blob/main/.github/workflows/sync-translations-zh-cn.yml).

### Prerequisites

Ensure the following secrets are configured in this repository:
- `ANTHROPIC_API_KEY`
- `QUANTECON_SERVICES_PAT` (with write access to `QuantEcon/lecture-intro.zh-cn`)

## TODO

- [x] setup review action-translation on `zh-cn` repo