### PR TITLE
[eigen_I.md] Update np.random → Generator API

### DIFF
--- a/lectures/eigen_I.md
+++ b/lectures/eigen_I.md
@@ -1005,7 +1005,8 @@ A = np.array([[1, 0, 3],
 num_iters = 20
 
 # Define a random starting vector b
-b = np.random.rand(A.shape[1])
+rng = np.random.default_rng()
+b = rng.random(A.shape[1])
 
 # Get the leading eigenvector of matrix A
 eigenvector = np.linalg.eig(A)[1][:, 0]


### PR DESCRIPTION
## Summary

This PR migrates the legacy NumPy random API to the Generator API as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

## Details

- In the solution block for exercise `eig1_ex1`, replaced `np.random.rand(A.shape[1])` with `rng = np.random.default_rng()` and `rng.random(A.shape[1])`.
- `rng` is defined inside the solution block so the block remains self-contained.
- No fixed seed was introduced (the original lecture did not use one).
- No Numba-related code is present in this file.
- No surrounding prose required updating.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
