### PR TITLE
[lln_clt.md] Update np.random → Generator API

### DIFF
--- a/lectures/lln_clt.md
+++ b/lectures/lln_clt.md
@@ -562,7 +562,8 @@ NumPy doesn't provide a `bernoulli` function that we can sample from.
 However, we can generate a draw of Bernoulli $X$ using NumPy via
 
 ```python3
-U = np.random.rand()
+rng = np.random.default_rng()
+U = rng.random()
 X = 1 if U < p else 0
 print(X)
 ```


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `lln_clt.md` to the Generator API as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

## Details

- In the `lln_ex2` exercise description, replaced `np.random.rand()` with `rng = np.random.default_rng()` and `rng.random()`.
- The code block is a static (non-executable) `python3` example used to illustrate Bernoulli sampling. The mathematical reasoning in the exercise and its solution remains unchanged.
- No fixed seed was introduced (the original code had none).
- No Numba-related code exists in this file.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
