### PR TITLE
[solow.md] Update np.random → Generator API

### DIFF
--- a/lectures/solow.md
+++ b/lectures/solow.md
@@ -589,13 +589,14 @@ s = 0.6
 α = 0.3
 δ = 0.5
 x0 = [.25, 3.25] # list of initial values used for simulation
+rng = np.random.default_rng()
 ```
 
 Let's define the function *k_next* to find the next value of $k$
 
 ```{code-cell} ipython3
 def lgnorm():
-    return np.exp(μ + σ * np.random.randn())
+    return np.exp(μ + σ * rng.standard_normal())
 
 def k_next(s, α, δ, k):
     return lgnorm() * s * k**α + (1 - δ) * k


### PR DESCRIPTION
## Summary

This PR migrates legacy NumPy random API usage in `solow.md` as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

- Replaced `np.random.randn()` with `rng.standard_normal()` in the `lognorm()` function inside the `solow_ex2` solution block.
- Added `rng = np.random.default_rng()` to the constants block at the start of the solution, keeping the solution block self-contained.
- No fixed seed introduced.
- No Numba-related code in this file.

## Details

`rng = np.random.default_rng()` was placed in the block headed by the comment `# Define the constants`. Strictly speaking, `rng` is not a model constant. If you feel the wording or placement should be adjusted (e.g. a blank line before `rng =`, or a separate comment), I would be happy to hear your thoughts.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
