### PR TITLE
Spelling and grammar fixes for unchecked lectures (#532)

### DIFF
--- a/lectures/french_rev.md
+++ b/lectures/french_rev.md
@@ -27,9 +27,9 @@ Some of those theories about monetary and fiscal policies still interest us toda
 
 * a **tax-smoothing** model like Robert Barro's {cite}`Barro1979`
 
-   * this normative (i.e., prescriptive model) advises a government to finance temporary war-time surges in expenditures mostly by issuing government debt, raising taxes by just enough to service the additional debt issued during the wary; then,   after the war,  to roll over whatever debt the government had accumulated during the war;  and  to increase taxes after the war permanently by just enough to finance interest payments on that post-war government  debt
+   * this normative (i.e., prescriptive model) advises a government to finance temporary war-time surges in expenditures mostly by issuing government debt, raising taxes by just enough to service the additional debt issued during the war; then,   after the war,  to roll over whatever debt the government had accumulated during the war;  and  to increase taxes after the war permanently by just enough to finance interest payments on that post-war government  debt
 
-*  **unpleasant monetarist arithmetic** like that described in this quanteon lecture  {doc}`unpleasant`
+*  **unpleasant monetarist arithmetic** like that described in this quantecon lecture  {doc}`unpleasant`
 
     * mathematics involving compound interest  governed French government debt dynamics in the decades preceding 1789; according to leading historians, that arithmetic set the stage for the French Revolution
 
@@ -50,7 +50,7 @@ Some of those theories about monetary and fiscal policies still interest us toda
 
 * a **legal restrictions**  or **financial repression** theory of the demand for real balances
 
-    * The Twelve Members comprising the Committee of Public Safety who adminstered the Terror from June 1793 to July 1794 used this theory to shape their monetary policy
+    * The Twelve Members comprising the Committee of Public Safety who administered the Terror from June 1793 to July 1794 used this theory to shape their monetary policy
 
 We use matplotlib to replicate several of the graphs with which  {cite}`sargent_velde1995` portrayed outcomes of these experiments
 
@@ -205,11 +205,11 @@ Figure {numref}`fr_fig2` indicates that
       * thus, after a war, the government does *not* raise taxes by enough to pay off its debt
       * instead, it just rolls over whatever debt it inherits, raising taxes by just enough to service the interest payments on that debt
 
-Eighteenth-century British fiscal policy portrayed Figure {numref}`fr_fig2` thus looks very much like a text-book example of a *tax-smoothing* model like Robert Barro's {cite}`Barro1979`.
+Eighteenth-century British fiscal policy portrayed in Figure {numref}`fr_fig2` thus looks very much like a text-book example of a *tax-smoothing* model like Robert Barro's {cite}`Barro1979`.
 
 A striking feature of the graph is what we'll label a *law of gravity* between tax collections and government expenditures.
 
-   * levels of government expenditures at taxes attract each other
+   * levels of government expenditures and taxes attract each other
    * while they can temporarily differ -- as they do during wars -- they come back together when peace returns
 
 
@@ -258,7 +258,7 @@ Figure  {numref}`fr_fig1` shows that interest payments on government debt (i.e.,
 
 {numref}`fr_fig2` showed us that in peace times Britain managed to balance its budget despite those large interest costs.
 
-But as  we'll see in our next graph, on the eve of the French Revolution in 1788, the  fiscal  *law of gravity* that worked so well in Britain did not  working very well in  France.
+But as  we'll see in our next graph, on the eve of the French Revolution in 1788, the  fiscal  *law of gravity* that worked so well in Britain did not  work very well in  France.
 
 ```{code-cell} ipython3
 # Read the data from the Excel file
@@ -310,7 +310,7 @@ This was partly a consequence of the unfolding of the debt dynamics that underli
 
 {cite}`sargent_velde1995` describe how the Ancient Regime that until 1788 had  governed France  had stable institutional features that made it difficult for the government to balance its budget.
 
-Powerful contending interests had prevented from the government from closing the gap between its
+Powerful contending interests had prevented the government from closing the gap between its
 total expenditures and its tax revenues by either
 
  * raising taxes, or
@@ -325,7 +325,7 @@ Precedents and prevailing French arrangements had empowered three constituencies
 
 When the French government had confronted a similar situation around 1720 after King  Louis XIV's
 Wars had left it with a debt crisis, it had sacrificed the interests of
-government creditors, i.e., by defaulting enough of its debt to bring  reduce interest payments down enough to balance the budget.
+government creditors, i.e., by defaulting on enough of its debt to bring interest payments down enough to balance the budget.
 
 Somehow, in 1789, creditors of the French government were more powerful than they had been in 1720.
 
@@ -333,7 +333,7 @@ Therefore, King Louis XVI convened the Estates General together to ask them to r
 allowing him to balance the budget while also honoring his promises to creditors of the French government.
 
 The King called the Estates General together in an effort to promote the reforms that would
-would bring sustained budget balance.
+bring sustained budget balance.
 
 {cite}`sargent_velde1995` describe how the French Revolutionaries set out to accomplish that.
 
@@ -356,14 +356,14 @@ about the same amount as the entire French government debt.
 
 This coincidence fostered a three step plan for servicing the French government debt
 
- * nationalize the church lands -- i.e., sequester or confiscate it without paying for it
+ * nationalize the church lands -- i.e., sequester or confiscate them without paying for them
  * sell the church lands
  * use the proceeds from those sales to service or even retire French government debt
 
 The monetary theory underlying this plan had been set out by Adam Smith in his analysis of what he called *real bills*  in his  1776 book
 **The Wealth of Nations**   {cite}`smith2010wealth`, which many of the revolutionaries had read.
 
-Adam Smith defined a *real bill* as a paper money note that is backed by a claims on a real asset like productive capital or inventories.
+Adam Smith defined a *real bill* as a paper money note that is backed by a claim on a real asset like productive capital or inventories.
 
 The National Assembly put together an ingenious institutional  arrangement to implement this plan.
 
@@ -412,7 +412,7 @@ They wanted to honor government debts -- interests of French government creditor
 But they set out to remake  the French tax code and the administrative machinery for collecting taxes.
 
   * they abolished many taxes
-  * they abolished the Ancient Regimes scheme for *tax farming*
+  * they abolished the Ancient Regime's scheme for *tax farming*
       * tax farming meant that the government had privatized tax collection by hiring private citizens -- so-called  tax farmers to collect taxes, while retaining a fraction of them as payment for their services
       * the great chemist Lavoisier was also a tax farmer, one of the reasons that the Committee for Public Safety sent him to the guillotine in 1794
 
@@ -424,7 +424,7 @@ The next figure shows this
 ---
 mystnb:
   figure:
-    caption: Index of real per capital revenues, France
+    caption: Index of real per capita revenues, France
     name: fr_fig5
 ---
 # Read data from Excel file
@@ -454,7 +454,7 @@ until after 1815, when Napoleon Bonaparte was exiled to St Helena and King Louis
   * from 1789 to 1799, the French Revolutionaries turned to another source to raise resources to pay for government purchases of goods and services and to service French government debt.
 
 And as the next figure shows, government expenditures exceeded tax revenues by substantial
-amounts during the period form 1789 to 1799.
+amounts during the period from 1789 to 1799.
 
 ```{code-cell} ipython3
 ---
@@ -604,7 +604,7 @@ plt.tight_layout()
 plt.show()
 ```
 
-We have partioned  {numref}`fr_fig9` that shows the log of the price level and   {numref}`fr_fig8`
+We have partitioned  {numref}`fr_fig9` that shows the log of the price level and   {numref}`fr_fig8`
 below  that plots real balances $\frac{M_t}{p_t}$ into three periods that correspond to  different monetary  experiments or *regimes*.
 
 The first period ends in the late summer of 1793, and is characterized
@@ -901,7 +901,7 @@ The following two graphs are for the classical hyperinflation period.
 
 One regresses inflation on real balances, the other regresses real balances on inflation.
 
-Both show a prounced inverse relationship that is the hallmark of the hyperinflations studied by
+Both show a pronounced inverse relationship that is the hallmark of the hyperinflations studied by
 Cagan {cite}`Cagan`.
 
 ```{code-cell} ipython3
@@ -977,7 +977,7 @@ period of the hyperinflation.
 {cite}`sargent_velde1995` tell how in 1797 the Revolutionary government abruptly ended the inflation by
 
   * repudiating 2/3 of the national debt, and thereby
-  * eliminating the net-of-interest government defict
+  * eliminating the net-of-interest government deficit
   * no longer printing money, but instead
   * using gold and silver coins as money
 

--- a/lectures/geom_series.md
+++ b/lectures/geom_series.md
@@ -457,7 +457,7 @@ $$
 - if $r=.05$, then $R = 1.05$
 
 **Remark:** The gross nominal interest rate $R$ is an **exchange
-rate** or **relative price** of dollars at between times $t$ and
+rate** or **relative price** of dollars between times $t$ and
 $t+1$. The units of $R$ are dollars at time $t+1$ per
 dollar at time $t$.
 
@@ -469,7 +469,7 @@ rate.
 
 - If I sell $x$ dollars to you today, you pay me $R x$
   dollars tomorrow.
-- This means that you borrowed $x$ dollars for me at a gross
+- This means that you borrowed $x$ dollars from me at a gross
   interest rate $R$ and a net interest rate $r$.
 
 We assume that the net nominal interest rate $r$ is fixed over
@@ -862,7 +862,7 @@ of national income, and investment is fixed.
 ---
 mystnb:
   figure:
-    caption: "Path of aggregate output tver time"
+    caption: "Path of aggregate output over time"
     name: path_of_aggregate_output_over_time
 ---
 # Function that calculates a path of y

--- a/lectures/greek_square.md
+++ b/lectures/greek_square.md
@@ -20,7 +20,7 @@ Chapter 24 of {cite}`russell2004history` about early Greek mathematics and astro
 fascinating passage:
 
  ```{epigraph} 
- The square root of 2, which was the first irrational to be discovered, was known to the early Pythagoreans, and ingenious methods of approximating to its value were discovered. The best was as follows: Form two columns of numbers, which we will call the $a$'s and the $b$'s; each starts with a $1$. The next $a$, at each stage, is formed by adding the last $a$ and the $b$ already obtained; the next $b$ is formed by adding twice the previous $a$ to the previous $b$. The first 6 pairs so obtained are $(1,1), (2,3), (5,7), (12,17), (29,41), (70,99)$. In each pair, $2 a^2 - b^2$ is $1$ or $-1$. Thus $b/a$ is nearly the square root of two, and at each fresh step it gets nearer. For instance, the reader may satisy himself that the square of $99/70$ is very nearly equal to $2$.
+ The square root of 2, which was the first irrational to be discovered, was known to the early Pythagoreans, and ingenious methods of approximating to its value were discovered. The best was as follows: Form two columns of numbers, which we will call the $a$'s and the $b$'s; each starts with a $1$. The next $a$, at each stage, is formed by adding the last $a$ and the $b$ already obtained; the next $b$ is formed by adding twice the previous $a$ to the previous $b$. The first 6 pairs so obtained are $(1,1), (2,3), (5,7), (12,17), (29,41), (70,99)$. In each pair, $2 a^2 - b^2$ is $1$ or $-1$. Thus $b/a$ is nearly the square root of two, and at each fresh step it gets nearer. For instance, the reader may satisfy himself that the square of $99/70$ is very nearly equal to $2$.
  ```
 
 This lecture drills down and studies this ancient method for computing square roots by using some of the matrix algebra that we've learned in earlier quantecon lectures. 
@@ -29,7 +29,7 @@ In particular, this lecture can be viewed as a sequel to {doc}`eigen_I`.
 
 It  provides an  example of how eigenvectors isolate  *invariant subspaces* that help construct and analyze solutions of linear difference equations. 
 
-When vector $x_t$ starts in an invariant subspace, iterating the different equation keeps $x_{t+j}$
+When vector $x_t$ starts in an invariant subspace, iterating the difference equation keeps $x_{t+j}$
 in that subspace for all $j \geq 1$.  
 
 Invariant subspace methods are used throughout applied economic dynamics, for example, in the lecture {doc}`money_inflation`.
@@ -112,8 +112,8 @@ $$ (eq:2diff3)
 
 where $\delta$ is a scalar to be determined.
 
-For initial condition that satisfy {eq}`eq:2diff3`
-equation {eq}`eq:2diff1` impllies that
+For initial conditions that satisfy {eq}`eq:2diff3`
+equation {eq}`eq:2diff1` implies that
 
 $$
 y_0 = \left(a_1 + \frac{a_2}{\delta}\right) y_{-1}.
@@ -176,7 +176,7 @@ If we choose $(y_{-1}, y_{-2})$ to set $(\eta_1, \eta_2) = (1, 0)$, then $y_t = 
 
 If we choose $(y_{-1}, y_{-2})$ to set $(\eta_1, \eta_2) = (0, 1)$, then $y_t = \delta_2^t$ for all $t \geq 0$.
 
-Soon we'll relate the preceding calculations to components an eigen decomposition of a transition matrix that represents difference equation {eq}`eq:2diff1` in a very convenient way.
+Soon we'll relate the preceding calculations to components of an eigen decomposition of a transition matrix that represents difference equation {eq}`eq:2diff1` in a very convenient way.
 
 We'll turn to that after we describe how Ancient Greeks figured out how to compute square roots of positive integers that are not perfect squares.
 
@@ -518,7 +518,7 @@ $$
 y_{t} = \lambda_i y_{t-1}, \quad i = 1, 2 
 $$ (eq:invariantsub101)
 
-that we encountered above in equation {eq}`eq:2diff8` above.
+that we encountered above in equation {eq}`eq:2diff8`.
 
 In equation {eq}`eq:invariantsub101`, the $i$th $\lambda_i$  equals the $V_{i, 1}/V_{i,2}$.
 
@@ -745,7 +745,7 @@ compute the matrix $A$.
 :class: dropdown
 ```
 
-Here is one soluition.
+Here is one solution.
 
 According to the quote, we can formulate 
 

--- a/lectures/inflation_history.md
+++ b/lectures/inflation_history.md
@@ -58,7 +58,7 @@ Often the price levels ended a century near where they started.
 
 Things were different in the 20th century, as we shall see in this lecture.
 
-A widely believed explanation of this big difference is that countries' abandoning gold and silver standards in the early twentieth century.
+A widely believed explanation of this big difference is that countries abandoned gold and silver standards in the early twentieth century.
 
 ```{tip}
 This lecture sets the stage for some subsequent lectures about a theory that macro economists use to think about determinants of the price level, namely, {doc}`cagan_ree` and {doc}`cagan_adaptive`
@@ -148,7 +148,7 @@ Keynes and Fisher proposed what they claimed would be a more efficient way to ac
 *  would be at least as firmly anchored as achieved under a gold or silver standard, and
 *  would also exhibit less year-to-year short-term fluctuations.
 
-They said that central bank could achieve price level stability by
+They said that central banks could achieve price level stability by
 
 * issuing  **limited supplies** of paper currency
 * refusing to print money to finance government expenditures
@@ -194,7 +194,7 @@ plt.tight_layout()
 plt.show()
 ```
 
-{numref}`lrpl_lg` shows that paper-money-printing central banks didn't do as well as the gold and standard silver standard in anchoring price levels.
+{numref}`lrpl_lg` shows that paper-money-printing central banks didn't do as well as the gold and silver standard in anchoring price levels.
 
 That would probably have surprised or disappointed Irving Fisher and John Maynard Keynes.
 

--- a/lectures/markov_chains_I.md
+++ b/lectures/markov_chains_I.md
@@ -515,7 +515,7 @@ mc.simulate(ts_length=4, init='unemployed')  # Start at unemployed initial state
 mc.simulate(ts_length=4)  # Start at randomly chosen initial state
 ```
 
-If we want to see indices rather than state values as outputs as  we can use
+If we want to see indices rather than state values as outputs, we can use
 
 ```{code-cell} ipython3
 mc.simulate_indices(ts_length=4)

--- a/lectures/networks.md
+++ b/lectures/networks.md
@@ -1104,7 +1104,7 @@ $$ (eicena)
 
 We see $e_j$ will be high if many nodes with high authority rankings link to $j$.
 
-The following figurenshows the authority-based eigenvector centrality ranking for the international
+The following figure shows the authority-based eigenvector centrality ranking for the international
 credit network shown in {numref}`financial_network`.
 
 ```{code-cell} ipython3

--- a/lectures/pv.md
+++ b/lectures/pv.md
@@ -478,7 +478,7 @@ $$
 $$ (eq:pieq2)
 
 Evidently, if $p_{T+1}^* = 0$, a price vector $p$ of all entries zero
-solves this equation and the only the **fundamental** component of our pricing
+solves this equation and only the **fundamental** component of our pricing
 formula {eq}`eq:ptpveq` is present.
 
 But let's activate the **bubble**  component by setting

--- a/lectures/scalar_dynam.md
+++ b/lectures/scalar_dynam.md
@@ -25,7 +25,7 @@ kernelspec:
 
 In economics many variables depend on their past values
 
-For example, it seems reasonable to believe that inflation last year with affects inflation this year.
+For example, it seems reasonable to believe that inflation last year affects inflation this year.
 
 (Perhaps high inflation last year will lead people to demand higher wages to
 compensate, which will feed into higher prices this year.)
@@ -37,7 +37,7 @@ $$ \pi_t = f(\pi_{t-1}) $$
 
 where $f$ is some function describing the relationship between the variables.
 
-This equation is an example of one-dimensional discrete time dynamic system.
+This equation is an example of a one-dimensional discrete time dynamic system.
 
 In this lecture we cover the foundations of one-dimensional discrete time
 dynamics.
@@ -98,7 +98,7 @@ In the example above, $f^n(x) = x^{1/(2^n)}$.
 ### Dynamic systems
 
 A **(discrete time) dynamic system** is a set $S$ and a function $g$ that sends
-set $S$ back into to itself.
+set $S$ back into itself.
 
 
 Examples of dynamic systems include
@@ -190,7 +190,7 @@ Continuing in this way, and using our knowledge of {doc}`geometric series
 We have an exact expression for $x_t$ for all non-negative integer $t$ and hence a full
 understanding of the dynamics.
 
-Notice in particular that $|a| < 1$, then, by {eq}`sdslinmod`, we have
+Notice in particular that if $|a| < 1$, then, by {eq}`sdslinmod`, we have
 
 ```{math}
 :label: sdslinmodc
@@ -225,7 +225,7 @@ k_{t+1} = s A k_t^{\alpha} + (1 - \delta) k_t
 
 Here $k=K/L$ is the per capita capital stock, $s$ is the saving rate, $A$ is the total factor productivity, $\alpha$ is the capital share, and $\delta$ is the depreciation rate. 
 
-All these parameter are positive and $0 < \alpha, \delta < 1$.
+All these parameters are positive and $0 < \alpha, \delta < 1$.
 
 If you try to iterate like we did in {eq}`sdslinmodpath`, you will find that
 the algebra gets messy quickly.

--- a/lectures/schelling.md
+++ b/lectures/schelling.md
@@ -44,7 +44,7 @@ preference for neighbors of the same race.
 For example, these agents might be comfortable with a mixed race neighborhood
 but uncomfortable when they feel "surrounded" by people from a different race.
 
-Schelling illustrated the follow surprising result: in such a setting, mixed
+Schelling illustrated the following surprising result: in such a setting, mixed
 race neighborhoods are likely to be unstable, tending to collapse over time.
 
 In fact the model predicts strongly divided neighborhoods, with high levels of

--- a/lectures/short_path.md
+++ b/lectures/short_path.md
@@ -142,7 +142,7 @@ implement it.
 
 ### The algorithm
 
-The standard algorithm for finding $J$ is to start an initial guess and then iterate.
+The standard algorithm for finding $J$ is to start with an initial guess and then iterate.
 
 This is a standard approach to solving nonlinear equations, often called
 the method of **successive approximations**.

--- a/lectures/simple_linear_regression.md
+++ b/lectures/simple_linear_regression.md
@@ -270,7 +270,7 @@ $$
 0 = \sum_{i=1}^{N}{y_i} - \sum_{i=1}^{N}{\alpha} - \beta \sum_{i=1}^{N}{x_i}
 $$
 
-The middle term is a straight forward sum from $i=1,...N$ by a constant $\alpha$
+The middle term is a straightforward sum from $i=1,...N$ by a constant $\alpha$
 
 $$
 0 = \sum_{i=1}^{N}{y_i} - N*\alpha - \beta \sum_{i=1}^{N}{x_i}
@@ -427,7 +427,7 @@ It is often a good idea to at first import a few lines of data from a csv to und
 
 You can observe that there are a bunch of columns we won't need to import such as `Continent`
 
-So let's built a list of the columns we want to import
+So let's build a list of the columns we want to import
 
 ```{code-cell} ipython3
 cols = ['Code', 'Year', 'Life expectancy at birth (historical)', 'GDP per capita']
@@ -442,7 +442,7 @@ df.columns = ["cntry", "year", "life_expectancy", "gdppc"]
 df
 ```
 
-We can see there are `NaN` values which represents missing data so let us go ahead and drop those
+We can see there are `NaN` values which represent missing data so let us go ahead and drop those
 
 ```{code-cell} ipython3
 df.dropna(inplace=True)

--- a/lectures/supply_demand_heterogeneity.md
+++ b/lectures/supply_demand_heterogeneity.md
@@ -38,7 +38,7 @@ from scipy.linalg import inv
 
 ## A simple example
 
-Let's study a simple example of **pure exchange** economy without production.
+Let's study a simple example of a **pure exchange** economy without production.
 
 There are two consumers who differ in their endowment vectors $e_i$ and their bliss-point vectors $b_i$ for $i=1,2$.
 

--- a/lectures/supply_demand_multiple_goods.md
+++ b/lectures/supply_demand_multiple_goods.md
@@ -297,7 +297,7 @@ For a Marshallian demand curve, hypothetical changes in a price vector have both
 
 For a Hicksian demand curve, hypothetical price vector changes have only **substitution** effects
 
-* changes in the price vector leave the $p^\top e + w$ unaltered because we freeze $\mu$ and solve for $w$
+* changes in the price vector leave $p^\top e + w$ unaltered because we freeze $\mu$ and solve for $w$
 
 Sometimes a Hicksian demand curve is called a **compensated** demand curve in order to emphasize that, to disarm the income (or wealth) effect associated with a price change, the consumer's wealth $w$ is adjusted.
 
@@ -771,7 +771,7 @@ Now let's construct an example of a production economy with one good.
 
 To do this we
 
-  * specify a single **person** and a **cost curve** in a way that let's us replicate the simple single-good supply demand example with which we started
+  * specify a single **person** and a **cost curve** in a way that lets us replicate the simple single-good supply demand example with which we started
 
   * compute equilibrium $p$ and $c$ and consumer and producer surpluses
 
@@ -844,7 +844,7 @@ This raises both the equilibrium price and quantity.
 
   * we'll do some experiments like those above
 
-  * we can do experiments with a **diagonal** $\Pi$ and also with a **non-diagonal** $\Pi$ matrices to study how cross-slopes affect responses of $p$ and $c$ to various shifts in $b$ (TODO)
+  * we can do experiments with a **diagonal** $\Pi$ and also with a **non-diagonal** $\Pi$ matrix to study how cross-slopes affect responses of $p$ and $c$ to various shifts in $b$ (TODO)
 
 ```{code-cell} ipython3
 Π = np.array([[1, 0],
@@ -964,7 +964,7 @@ $$
 
 which the monopolist equates to its marginal cost.
 
-The plot indicates that the monopolist's sets output  lower than either the competitive equilibrium quantity.
+The plot indicates that the monopolist sets output lower than the competitive equilibrium quantity.
 
 In a single good case, this equilibrium is associated with a higher price of the good.
 


### PR DESCRIPTION
Addresses the remaining unchecked lectures in #532 with a bulk, **conservative** spelling/grammar/typo pass — only unambiguous fixes (misspellings, doubled words, missing articles/prepositions, clear agreement errors). No wording or stylistic rewrites. Each lecture is committed separately so individual changes can be reverted in isolation.

### Lectures fixed (48 fixes across 13 files)
- **french_rev** (17): `wary`→`war`, `adminstered`→`administered`, `defict`→`deficit`, `per capital`→`per capita`, `partioned`→`partitioned`, `prounced`→`pronounced`, doubled `would would`, `prevented from the government from`→`prevented the government from`, `expenditures at taxes`→`expenditures and taxes`, and more
- **greek_square** (7): `satisy`→`satisfy`, `different equation`→`difference equation`, `impllies`→`implies`, `soluition`→`solution`, doubled `above`, `condition`→`conditions`, missing `of`
- **scalar_dynam** (5): stray `with`, missing article `a`, `into to`→`into`, `parameter`→`parameters`, missing `if`
- **geom_series** (3): `for me`→`from me`, `tver`→`over`, stray `at`
- **inflation_history** (3): `central bank`→`central banks`, `gold and standard silver standard`→`gold and silver standard`, sentence-fragment fix
- **simple_linear_regression** (3): `let's built`→`let's build`, `represents`→`represent`, `straight forward`→`straightforward`
- **supply_demand_multiple_goods** (4): `let's us`→`lets us`, `monopolist's sets`→`monopolist sets`, `matrices`→`matrix`, stray article
- **markov_chains_I, networks, pv, schelling, short_path, supply_demand_heterogeneity** (1 each): e.g. `figurenshows`→`figure shows`, `the only the`→`only the`, `follow`→`following`, `start an initial guess`→`start with an initial guess`

### Clean — no changes needed
`olg`, `prob_dist`, `solow`

### Not included
- `ak2` — not present on `main` (PR #508 was never merged)
- `monte_carlo` — skipped to avoid conflict with open PR #754

### Left for author judgment (not clear-cut typos)
- A garbled `our consumer confronts **risk** means...` passage in `supply_demand_multiple_goods`
- A dangling `We apply the ideas discussed in this lecture to:` line in `networks`
- A redundant `Estates General together` phrasing in `french_rev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)