### PR TITLE
Update business cycle data to latest available (#364)

### DIFF
--- a/lectures/business_cycle.md
+++ b/lectures/business_cycle.md
@@ -184,13 +184,6 @@ def plot_series(data, country, ylabel,
         ax.axhline(y=baseline,
                    color='black',
                    linestyle='--')
-
-    # Pin the most recent year as an x-axis tick
-    final_year = data.columns.max()
-    ax.set_xlim(right=final_year)
-    xticks = [t for t in ax.get_xticks() if t <= final_year - 3]
-    ax.set_xticks(xticks + [final_year])
-
     ax.set_ylabel(ylabel)
     ax.legend()
     return ax
@@ -493,13 +486,6 @@ def plot_comparison(data, countries,
             'GFC\n(2008)', **t_params)
     ax.text(2020, ylim + ylim*txt_pos,
             'Covid-19\n(2020)', **t_params)
-
-    # Pin the most recent year as an x-axis tick
-    final_year = data.columns.max()
-    ax.set_xlim(right=final_year)
-    xticks = [t for t in ax.get_xticks() if t <= final_year - 3]
-    ax.set_xticks(xticks + [final_year])
-
     if baseline != None:
         ax.hlines(y=baseline, xmin=ax.get_xlim()[0],
                   xmax=ax.get_xlim()[1], color='black',

--- a/lectures/business_cycle.md
+++ b/lectures/business_cycle.md
@@ -175,6 +175,13 @@ def plot_series(data, country, ylabel,
         ax.axhline(y=baseline,
                    color='black',
                    linestyle='--')
+
+    # Pin the most recent year as an x-axis tick
+    final_year = data.columns.max()
+    ax.set_xlim(right=final_year)
+    xticks = [t for t in ax.get_xticks() if t <= final_year - 3]
+    ax.set_xticks(xticks + [final_year])
+
     ax.set_ylabel(ylabel)
     ax.legend()
     return ax
@@ -316,7 +323,7 @@ economy recessions in the 1970s and 1990s.
 
 Another important measure of business cycles is the unemployment rate.
 
-We study unemployment using rate data from FRED spanning from [1929-1942](https://fred.stlouisfed.org/series/M0892AUSM156SNBR) to [1948-2022](https://fred.stlouisfed.org/series/UNRATE), combined unemployment rate data over 1942-1948 estimated by the [Census Bureau](https://www.census.gov/library/publications/1975/compendia/hist_stats_colonial-1970.html).
+We study unemployment using rate data from FRED spanning from [1929-1942](https://fred.stlouisfed.org/series/M0892AUSM156SNBR) to [1948 onwards](https://fred.stlouisfed.org/series/UNRATE), combined unemployment rate data over 1942-1948 estimated by the [Census Bureau](https://www.census.gov/library/publications/1975/compendia/hist_stats_colonial-1970.html).
 
 ```{code-cell} ipython3
 :tags: [hide-input]
@@ -330,13 +337,13 @@ unrate_history.rename(columns={'M0892AUSM156SNBR': 'UNRATE'},
                 inplace=True)
 
 start_date = datetime.datetime(1948, 1, 1)
-end_date = datetime.datetime(2022, 12, 31)
+end_date = datetime.datetime.now()
 
 unrate = web.DataReader('UNRATE', 'fred',
                     start_date, end_date)
 ```
 
-Let's plot the unemployment rate in the US from 1929 to 2022 with recessions
+Let's plot the unemployment rate in the US from 1929 to the present with recessions
 defined by the NBER.
 
 ```{code-cell} ipython3
@@ -359,7 +366,7 @@ unrate_census.set_index('DATE', inplace=True)
 
 # Obtain the NBER-defined recession periods
 start_date = datetime.datetime(1929, 1, 1)
-end_date = datetime.datetime(2022, 12, 31)
+end_date = datetime.datetime.now()
 
 nber = web.DataReader('USREC', 'fred', start_date, end_date)
 
@@ -479,6 +486,13 @@ def plot_comparison(data, countries,
             'GFC\n(2008)', **t_params)
     ax.text(2020, ylim + ylim*txt_pos,
             'Covid-19\n(2020)', **t_params)
+
+    # Pin the most recent year as an x-axis tick
+    final_year = data.columns.max()
+    ax.set_xlim(right=final_year)
+    xticks = [t for t in ax.get_xticks() if t <= final_year - 3]
+    ax.set_xticks(xticks + [final_year])
+
     if baseline != None:
         ax.hlines(y=baseline, xmin=ax.get_xlim()[0],
                   xmax=ax.get_xlim()[1], color='black',
@@ -616,7 +630,7 @@ of Michigan.
 Here we plot the University of Michigan Consumer Sentiment Index and
 year-on-year
 [core consumer price index](https://fred.stlouisfed.org/series/CPILFESL)
-(CPI) change from 1978-2022 in the US.
+(CPI) change from 1978 to the present in the US.
 
 ```{code-cell} ipython3
 ---
@@ -628,11 +642,11 @@ tags: [hide-input]
 ---
 
 start_date = datetime.datetime(1978, 1, 1)
-end_date = datetime.datetime(2022, 12, 31)
+end_date = datetime.datetime.now()
 
 # Limit the plot to a specific range
 start_date_graph = datetime.datetime(1977, 1, 1)
-end_date_graph = datetime.datetime(2023, 12, 31)
+end_date_graph = end_date + datetime.timedelta(days=365)
 
 nber = web.DataReader('USREC', 'fred', start_date, end_date)
 consumer_confidence = web.DataReader('UMCSENT', 'fred',
@@ -698,7 +712,7 @@ However, it is not a leading indicator, as the peak of contraction in production
 is delayed relative to consumer confidence and inflation.
 
 We plot the real industrial output change from the previous year
-from 1919 to 2022 in the US to show this trend.
+from 1919 to the present in the US to show this trend.
 
 ```{code-cell} ipython3
 ---
@@ -710,7 +724,7 @@ tags: [hide-input]
 ---
 
 start_date = datetime.datetime(1919, 1, 1)
-end_date = datetime.datetime(2022, 12, 31)
+end_date = datetime.datetime.now()
 
 nber = web.DataReader('USREC', 'fred',
                     start_date, end_date)
@@ -746,7 +760,7 @@ activity and gloomy expectations for the future.
 One example is domestic credit to the private sector by banks in the UK.
 
 The following graph shows the domestic credit to the private sector as a
-percentage of GDP by banks from 1970 to 2022 in the UK.
+percentage of GDP by banks from 1970 to the present in the UK.
 
 ```{code-cell} ipython3
 ---

--- a/lectures/business_cycle.md
+++ b/lectures/business_cycle.md
@@ -53,6 +53,15 @@ cycler = plt.cycler(linestyle=['-', '-.', '--', ':'],
 plt.rc('axes', prop_cycle=cycler)
 ```
 
+We pull all time series through to the most recent available data.
+
+```{code-cell} ipython3
+# The cutoff date for the data we fetch below.
+# To freeze the data for a reproducible build, replace this with a
+# fixed date such as datetime.datetime(2024, 12, 31).
+end_date = datetime.datetime.now()
+```
+
 
 ## Data acquisition
 
@@ -329,15 +338,14 @@ We study unemployment using rate data from FRED spanning from [1929-1942](https:
 :tags: [hide-input]
 
 start_date = datetime.datetime(1929, 1, 1)
-end_date = datetime.datetime(1942, 6, 1)
+hist_end_date = datetime.datetime(1942, 6, 1)
 
 unrate_history = web.DataReader('M0892AUSM156SNBR',
-                    'fred', start_date,end_date)
+                    'fred', start_date, hist_end_date)
 unrate_history.rename(columns={'M0892AUSM156SNBR': 'UNRATE'},
                 inplace=True)
 
 start_date = datetime.datetime(1948, 1, 1)
-end_date = datetime.datetime.now()
 
 unrate = web.DataReader('UNRATE', 'fred',
                     start_date, end_date)
@@ -366,7 +374,6 @@ unrate_census.set_index('DATE', inplace=True)
 
 # Obtain the NBER-defined recession periods
 start_date = datetime.datetime(1929, 1, 1)
-end_date = datetime.datetime.now()
 
 nber = web.DataReader('USREC', 'fred', start_date, end_date)
 
@@ -405,10 +412,10 @@ The plot shows that
 * cycles are, in general, asymmetric: sharp rises in unemployment are followed
   by slow recoveries.
 
-It also shows us how unique labor market conditions were in the US during the
-post-pandemic recovery.
+It also shows how unusual the US labor market was in the recovery from the 2020
+pandemic shock.
 
-The labor market recovered at an unprecedented rate after the shock in 2020-2021.
+Unemployment spiked sharply in 2020 and then fell back at an unprecedented rate.
 
 
 (synchronization)=
@@ -642,7 +649,6 @@ tags: [hide-input]
 ---
 
 start_date = datetime.datetime(1978, 1, 1)
-end_date = datetime.datetime.now()
 
 # Limit the plot to a specific range
 start_date_graph = datetime.datetime(1977, 1, 1)
@@ -724,7 +730,6 @@ tags: [hide-input]
 ---
 
 start_date = datetime.datetime(1919, 1, 1)
-end_date = datetime.datetime.now()
 
 nber = web.DataReader('USREC', 'fred',
                     start_date, end_date)


### PR DESCRIPTION
Closes #364.

## What

The World Bank series in `business_cycle.md` already auto-fetch the most recent year. The **FRED** pulls, however, had `end_date = datetime.datetime(2022, 12, 31)` hardcoded in four places, capping the unemployment, NBER-recession, consumer-sentiment/CPI, and industrial-output series at 2022.

- Switch the FRED data window to the latest available data, and define the cutoff **once** as a shared `end_date` variable with a documented one-line switch to pin it for reproducible builds (instead of repeating `datetime.now()` across cells).
- Rename the unemployment cell's fixed 1942 cutoff to `hist_end_date` so it no longer clobbers the shared `end_date`.
- Update the consumer-sentiment plot's `end_date_graph` to track the dynamic end date instead of a hardcoded 2023.
- Update prose that hardcoded "2022" to read "the present", and reword the post-pandemic labour-market sentence to be anchored to the 2020 shock rather than the moving right edge of the chart.

## Narrative check

I re-read the prose against what the extended data shows:
- The consumer sentiment / CPI section is *reinforced* — it now captures the 2021–2023 inflation surge and matching sentiment drop.
- The "unprecedented post-pandemic labour-market recovery" and US "trending slightly downward" claims still hold with the fuller series.
- The GDP charts' recession highlight bands remain a curated set of four reference recessions (Oil Crisis, 1990s, GFC, Covid); they are intentionally not exhaustive.

## Note

An earlier revision pinned the final year as an explicit x-axis tick, but it crowded the existing 2020 ("Covid-19") tick, so it was reverted — the charts use matplotlib's default ticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)