### PR TITLE
[inequality] Take writeable copy before rd.shuffle (pandas 3.0 read-only fix)

### DIFF
--- a/lectures/inequality.md
+++ b/lectures/inequality.md
@@ -284,7 +284,8 @@ for var in varlist:
         # Repeat the observations according to their weights
         counts = list(round(df[df['year'] == year]['weights'] ))
         y = df[df['year'] == year][var].repeat(counts)
-        y = np.asarray(y)
+        # `.copy()` gives a writeable array (pandas 3.0 returns a read-only one)
+        y = np.asarray(y).copy()
 
         # Shuffle the sequence to improve the plot
         rd.shuffle(y)


### PR DESCRIPTION
Under the `anaconda=2026.06` stack (pandas 3.0), `np.asarray()` of a Series returns a **read-only** array (Copy-on-Write), so the in-place `rd.shuffle(y)` in the Lorenz-curve loop raised `ValueError: assignment destination is read-only` and aborted execution of `inequality.md`. This takes a writeable `.copy()` before the shuffle.

This clears one of the two `anaconda=2026.06` build failures tracked in #775. The other two notebooks (`input_output`, `networks`) are blocked by an upstream `quantecon_book_networks` issue (QuantEcon/quantecon-book-networks#21), so the cache build won't be fully green until that lands (or `setuptools` is added as a stopgap).

Found during the cross-repo anaconda 2026.06 validation sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
