### PR TITLE
Pin quantecon_book_networks==1.6 to unblock input_output + networks

### DIFF
--- a/lectures/input_output.md
+++ b/lectures/input_output.md
@@ -20,7 +20,7 @@ This lecture requires the following imports and installs before we proceed.
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install quantecon_book_networks
+!pip install quantecon_book_networks==1.6
 !pip install quantecon
 !pip install pandas-datareader
 ```

--- a/lectures/networks.md
+++ b/lectures/networks.md
@@ -16,7 +16,7 @@ kernelspec:
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install quantecon-book-networks pandas-datareader
+!pip install quantecon-book-networks==1.6 pandas-datareader
 ```
 
 ## Outline


### PR DESCRIPTION
Pins `quantecon_book_networks==1.6` in the `input_output` and `networks` lectures, picking up the upstream `pkg_resources` fix released today.

## Why

Under the anaconda 2026.06 upgrade (#773), `input_output.md` and `networks.md` failed to execute because `quantecon_book_networks/data.py` ran `import pkg_resources` at module load, and `pkg_resources` is no longer present on the 2026.06 stack:

> `ModuleNotFoundError: No module named 'pkg_resources'`

`quantecon_book_networks` 1.6 (published 2026-06-26) migrates `data.py` off `pkg_resources` to the stdlib `importlib.resources`, so the package imports cleanly again. `importlib.resources.files` is available on all supported Python versions, so 1.6 also works on the current 2025.12 stack — there is no regression on `main`. This ports the upstream fix from QuantEcon/quantecon_book_networks#21.

## Changes

| File | Before | After |
|---|---|---|
| `lectures/input_output.md` | `!pip install quantecon_book_networks` | `!pip install quantecon_book_networks==1.6` |
| `lectures/networks.md` | `!pip install quantecon-book-networks pandas-datareader` | `!pip install quantecon-book-networks==1.6 pandas-datareader` |

The package is installed via in-cell `!pip install` rather than `environment.yml`, so the pin lives in the lecture cells. #775 explicitly called for the fixed version to be pinned here.

## Context

This addresses **cause 2** of #775 (the `quantecon_book_networks` / `pkg_resources` failures). **Cause 1** — the pandas 3.0 read-only array in `inequality.md` — is handled separately in #776. With both merged, a re-run of the "Build Cache" workflow validating the anaconda 2026.06 bump (#773) should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)