### PR TITLE
Migrate GH Pages deploy to artifact-based deployment

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -9,6 +9,7 @@ jobs:
     name: QuantEcon AI link checking
     runs-on: "ubuntu-latest"
     permissions:
+      contents: read  # read latest release assets via gh api
       issues: write   # required for QuantEcon link-checker
     steps:
       # Download the latest release HTML archive (permanent, not subject to artifact expiry)
@@ -17,13 +18,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           ASSET_URL=$(gh api repos/${{ github.repository }}/releases/latest \
-            --jq '.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url')
-          echo "asset-url=$ASSET_URL" >> $GITHUB_OUTPUT
+            --jq '[.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url] | first // ""')
+          if [ -z "$ASSET_URL" ]; then
+            echo "::error::No .tar.gz asset found on the latest release"
+            exit 1
+          fi
+          echo "asset-url=$ASSET_URL" >> "$GITHUB_OUTPUT"
       - name: Download and extract release HTML
         run: |
+          set -euo pipefail
           mkdir -p _site
-          curl -sL "${{ steps.release.outputs.asset-url }}" | tar -xz -C _site
+          curl -fsSL "${{ steps.release.outputs.asset-url }}" | tar -xz -C _site
       - name: AI-Powered Link Checker
         uses: QuantEcon/action-link-checker@main
         with:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -6,26 +6,29 @@ on:
   workflow_dispatch:
 jobs:
   link-checking:
-    name: Link Checking
+    name: QuantEcon AI link checking
     runs-on: "ubuntu-latest"
     permissions:
-      issues: write # required for peter-evans/create-issue-from-file
+      issues: write   # required for QuantEcon link-checker
     steps:
-      # Checkout the live site (html)
-      - name: Checkout
-        uses: actions/checkout@v7
+      # Download the latest release HTML archive (permanent, not subject to artifact expiry)
+      - name: Get latest release asset URL
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ASSET_URL=$(gh api repos/${{ github.repository }}/releases/latest \
+            --jq '.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url')
+          echo "asset-url=$ASSET_URL" >> $GITHUB_OUTPUT
+      - name: Download and extract release HTML
+        run: |
+          mkdir -p _site
+          curl -sL "${{ steps.release.outputs.asset-url }}" | tar -xz -C _site
+      - name: AI-Powered Link Checker
+        uses: QuantEcon/action-link-checker@main
         with:
-          ref: gh-pages
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@v2
-        with:
-          fail: false
-          args: --accept 200..=299,403,503 --base-url https://intro.quantecon.org *.html
-      - name: Create Issue From File
-        if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v6
-        with:
-          title: Link Checker Report
-          content-filepath: ./lychee/out.md
-          labels: report, automated issue, linkchecker
+          html-path: '_site'
+          fail-on-broken: 'false'
+          silent-codes: '403,503'
+          ai-suggestions: 'true'
+          create-issue: 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,27 @@
-name: Build & Publish to GH-PAGES
+name: Build & Publish to GH Pages
 on:
   push:
     tags:
       - 'publish*'
+
+permissions:
+  contents: write   # upload release assets; Netlify commit comment
+  actions: read     # dawidd6 download-artifact reads cache.yml's build-cache
+  statuses: write   # Netlify commit status
+  pages: write      # deploy to GitHub Pages
+  id-token: write   # OIDC token for actions/deploy-pages
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -110,12 +125,17 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      - name: Deploy website to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Add CNAME for custom domain
+        run: echo "intro.quantecon.org" > _build/html/CNAME
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/html/
-          cname: intro.quantecon.org
+          path: _build/html/
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
       - name: Upload "_build" folder (cache)
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

Migrates GitHub Pages deployment from the `gh-pages` branch (`peaceiris/actions-gh-pages`) to native artifact-based deployment, following the QuantEcon infrastructure guide in QuantEcon/meta#282. `lecture-python-programming` was migrated the same way in QuantEcon/lecture-python-programming#499. Once the `gh-pages` branch is deleted (final step, after verification), the repo drops from **~767 MB to ~15 MB**.

This PR only touches the two workflow files. **Merging it changes nothing on the live site** — the site keeps serving from `gh-pages` until we flip the Pages source in repo Settings (a manual post-merge step). So there is no downtime window from merging.

## What changed

**`publish.yml`**
- Adds a top-level `permissions` block, a `pages` concurrency group, and the `github-pages` environment on the job.
- Replaces the `peaceiris/actions-gh-pages@v4` step with `configure-pages@v6` + `upload-pages-artifact@v5` + `deploy-pages@v5`, writing `intro.quantecon.org` into `_build/html/CNAME` first.
- The Netlify deploy, release-asset upload, `_build` cache upload, and notebook sync are all left untouched.

**`linkcheck.yml`**
- Replaces the `gh-pages` checkout (which won't exist after migration) with a download of the latest release `.tar.gz`, and swaps lychee for `QuantEcon/action-link-checker@main` — matching the standard now used by `lecture-python-programming`.

## Note on the `permissions` block

The workflow previously ran with the default permissive token. Because specifying `permissions:` resets every unlisted scope to `none`, the block enumerates everything this workflow actually needs. Two entries are specific to this repo (the programming reference did not need them):

| Permission | Why it is required here |
|---|---|
| `contents: write` | Release-asset upload (`softprops/action-gh-release`) and Netlify commit comment |
| `actions: read` | `dawidd6/action-download-artifact` pulls the `build-cache` artifact from `cache.yml` |
| `statuses: write` | Netlify step posts a commit status |
| `pages: write` | `actions/deploy-pages` |
| `id-token: write` | OIDC token required by `actions/deploy-pages` |

## Post-merge steps (manual — do NOT skip the order)

Per QuantEcon/meta#282 §7.2, after this merges:

1. Settings → Pages → set Source to **GitHub Actions**.
2. Settings → Environments → `github-pages` → add a **Tag** deployment rule `publish*` (without this the first tag deploy fails with *"Tag is not allowed to deploy… due to environment protection rules"*).
3. Push a test `publish-*` tag and watch the run.
4. Verify: site loads, `build_type: workflow`, release assets attached, notebook sync ran, Netlify deployed.
5. Run linkcheck via `workflow_dispatch` and confirm it downloads the release asset.
6. Delete the `gh-pages` branch and notify the team to prune locally.

## Rollback

If anything looks wrong before step 6: Settings → Pages → Source → "Deploy from a branch" → `gh-pages`, and the site immediately serves from the old branch again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
