### PR TITLE
Adopt quantecon/actions/publish-gh-pages for GitHub Pages deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page-url }}
+      url: ${{ steps.deployment.outputs['page-url'] }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page-url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -89,32 +89,6 @@ jobs:
         run: |
           rm -r _build/.doctrees
           jb build lectures --path-output ./
-      # Create HTML archive for release assets
-      - name: Create HTML archive
-        shell: bash -l {0}
-        run: |
-          tar -czf lecture-python-intro-html-${{ github.ref_name }}.tar.gz -C _build/html .
-          sha256sum lecture-python-intro-html-${{ github.ref_name }}.tar.gz > html-checksum.txt
-
-          # Create metadata manifest
-          cat > html-manifest.json << EOF
-          {
-            "tag": "${{ github.ref_name }}",
-            "commit": "${{ github.sha }}",
-            "timestamp": "$(date -Iseconds)",
-            "size_mb": $(du -sm _build/html | cut -f1),
-            "file_count": $(find _build/html -type f | wc -l)
-          }
-          EOF
-      - name: Upload archives to release
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            lecture-python-intro-html-${{ github.ref_name }}.tar.gz
-            html-checksum.txt
-            html-manifest.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v4.0
         with:
@@ -125,17 +99,16 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      - name: Add CNAME for custom domain
-        run: echo "intro.quantecon.org" > _build/html/CNAME
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: _build/html/
+      # Deploy to GitHub Pages + publish release assets (html archive, checksum, manifest)
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: quantecon/actions/publish-gh-pages@v0.8.0
+        with:
+          build-dir: _build/html
+          cname: intro.quantecon.org
+          create-release-assets: 'true'
+          asset-name: 'lecture-python-intro-html'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload "_build" folder (cache)
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Migrates the GitHub Pages deploy to `quantecon/actions/publish-gh-pages@v0.8.0`, bringing this repo onto the same publish action as the rest of the lecture family. Part of the standardization tracked in QuantEcon/lectures#11.

## What changed

One composite step replaces six hand-rolled steps — the inline release-asset packaging (`tar` + `sha256sum` + `manifest.json` → `softprops/action-gh-release`) and the native Pages deploy (`configure-pages` → `upload-pages-artifact` → `deploy-pages`):

- `uses: quantecon/actions/publish-gh-pages@v0.8.0` with `build-dir`, `cname: intro.quantecon.org`, `create-release-assets: 'true'`, `asset-name`, `github-token`.
- `environment.url` now reads the composite's output name (`page-url`).

## Scope — deploy only, no build change

The `jb build` steps (including the `.doctrees` clear and nitpick flags), the PDF/notebook asset builds, the notebook sync to `lecture-python-intro.notebooks`, and the **Netlify deploy are all untouched**. This is the same deploy-step swap the five composite repos already run in production, so the build-behavior differences don't apply here.

## Behavioral notes

- The **release tarball name is unchanged** (`lecture-python-intro-html-<tag>.tar.gz`). The **checksum/manifest filenames change** from the fixed `html-checksum.txt` / `html-manifest.json` to `lecture-python-intro-html-checksum.txt` / `-manifest.json`, and the manifest gains `name` + `repository` fields — matching the convention the other repos already use.
- Verify with the first `publish*` tag after merge.

References: [publish-gh-pages@v0.8.0](https://github.com/QuantEcon/actions/tree/v0.8.0/publish-gh-pages)
