### PR TITLE
Adopt minimal proof/exercise styling

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -79,6 +79,8 @@ sphinx:
     suppress_warnings: [mystnb.unknown_mime_type, myst.domains]
     # sphinx-proof
     proof_minimal_theme: true
+    # sphinx-exercise
+    exercise_style: "solution_follow_exercise"
     # -------------
     html_js_files:
       - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js


### PR DESCRIPTION
## What

Add `exercise_style: "solution_follow_exercise"` to `lectures/_config.yml`. The minimal proof theme (`proof_minimal_theme: true`) is already set, so this brings `intro` fully in line with the minimal styling.

## Why

Part of a cross-series harmonization so every Python lecture series uses the same minimal exercise layout. `intro` was the only series with the minimal proof theme but not the `solution_follow_exercise` exercise style. See the audit and checklist in QuantEcon/workspace-lectures#13.

## Note

Config-only change; no lecture content touched.
