### PR TITLE
ENH: add zh-cn translation sync workflow (Phase 0, Track A)

### DIFF
--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -1,0 +1,35 @@
+# Sync Translations — Simplified Chinese
+# On merged PR, translate changed lectures into the zh-cn target repo.
+# Comment \translate-resync on a merged PR to re-trigger sync.
+name: Sync Translations (Simplified Chinese)
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'lectures/**/*.md'
+      - 'lectures/_toc.yml'
+  issue_comment:
+    types: [created]
+
+jobs:
+  sync:
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - uses: QuantEcon/action-translation@v0
+        with:
+          mode: sync
+          target-repo: QuantEcon/lecture-intro.zh-cn
+          target-language: zh-cn
+          source-language: en
+          docs-folder: lectures
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}


### PR DESCRIPTION
Adds `.github/workflows/sync-translations-zh-cn.yml`, copying the proven lecture-python-programming pattern: on merged PRs touching `lectures/`, [action-translation](https://github.com/QuantEcon/action-translation)`@v0` translates changed sections and opens a PR in QuantEcon/lecture-intro.zh-cn. Manual re-trigger via a `\translate-resync` issue comment.

**Hold for sequencing** — merge only after the target repo's onboarding lands (heading maps + `.translate/` state bootstrap, per the connect-existing tutorial), so the first automated sync runs against a mapped, current baseline. Wiring order tracked in #782.

Secrets: `ANTHROPIC_API_KEY` and `QUANTECON_SERVICES_PAT` are available to this repo as org-level secrets (verified 2026-07-18).

Part of Phase 0 Track A (#782); program tracker QuantEcon/action-translation#74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)