### PR TITLE
FIX: remove unused get_cmap and to_rgba imports in laffer_adaptive

### DIFF
--- a/lectures/laffer_adaptive.md
+++ b/lectures/laffer_adaptive.md
@@ -171,7 +171,6 @@ from collections import namedtuple
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
-from matplotlib.cm import get_cmap
 from matplotlib.colors import to_rgba
 import matplotlib
 from scipy.optimize import root, fsolve

--- a/lectures/laffer_adaptive.md
+++ b/lectures/laffer_adaptive.md
@@ -171,7 +171,6 @@ from collections import namedtuple
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
-from matplotlib.colors import to_rgba
 import matplotlib
 from scipy.optimize import root, fsolve
 ```


### PR DESCRIPTION
## Problem

anaconda 2026.07 ships a matplotlib that has finally removed the long-deprecated `matplotlib.cm.get_cmap`. The first code cell of `laffer_adaptive.md` imports it, so the notebook now fails at import time before executing anything:

    ImportError: cannot import name 'get_cmap' from 'matplotlib.cm'

This surfaced while validating the anaconda 2026.06 → 2026.07 bump (#797): the `cache.yml` run on that branch ([run 29685190525](https://github.com/QuantEcon/lecture-python-intro/actions/runs/29685190525)) failed with exactly one broken notebook — this one. Every other lecture built clean under `-W --keep-going`.

## Fix

Two dead imports are dropped from that cell:

| Import | Status | Why removed |
|---|---|---|
| `from matplotlib.cm import get_cmap` | **Fatal** under anaconda 2026.07 | Never used in the lecture — dropped rather than migrated to `matplotlib.colormaps[...]` |
| `from matplotlib.colors import to_rgba` | Harmless but dead | Never used in the lecture; `to_rgba` still exists in matplotlib, so this is cleanup rather than a fix |

Both were verified unused by checking every occurrence in the file — each symbol appears exactly once, on its own import line, with no reference anywhere else (compare `MaxNLocator`, `namedtuple` and `fsolve`, which are each imported *and* used). Two lines deleted, no output changes.

## Why this targets `main` rather than the dependabot branch

The dead import is a latent bug independent of the env bump — it just happens to become fatal under 2026.07. Landing it on `main` keeps the dependabot PR a clean `environment.yml`-only diff, matching how the compat fixes were handled during the 2026.06 round (#776, #777). Once this merges I'll rebase #797 and re-dispatch `cache.yml` to confirm a fully green validation build.

Cross-repo validation status is tracked in QuantEcon/workspace-lectures#21.

Note for reviewers: the bare `import matplotlib` on the following line also appears to be unused — there are no `matplotlib.<attr>` references outside the import block. I have left it in place as it is out of scope for this fix, but happy to drop it here if preferred.
