### PR TITLE
FIX: install quantecon in networks.md

### DIFF
--- a/lectures/networks.md
+++ b/lectures/networks.md
@@ -16,7 +16,9 @@ kernelspec:
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install quantecon-book-networks==1.6 pandas-datareader
+!pip install quantecon
+!pip install quantecon-book-networks==1.6
+!pip install pandas-datareader
 ```
 
 ## Outline


### PR DESCRIPTION
Closes #801.

`lectures/networks.md` imports `quantecon` at line 56 but its pip cell only installs `quantecon-book-networks==1.6` and `pandas-datareader`. The lecture builds today because `markov_chains_I` (TOC 35), `markov_chains_II` (36) and `eigen_II` (40) each run `!pip install quantecon` into the same runner environment before `networks` (43) executes, and pip installs persist across notebooks within a build. A full cold build therefore satisfies the dependency by accident.

That guarantee disappears the moment the lecture executes on its own — which is the normal case, not an edge case. With a warm `jupyter-cache`, a one-line edit to `networks.md` re-executes only that notebook and serves every other lecture from cache, so none of the earlier pip cells fire. This was observed in the Chinese edition ([lecture-intro.zh-cn#276](https://github.com/QuantEcon/lecture-intro.zh-cn/pull/276)), which carries the identical gap because it is a faithful translation of this file: `ModuleNotFoundError: No module named 'quantecon'` in the imports cell, after months of green builds.

Confirmed that `quantecon` is not in `environment.yml` either — it reaches the build environment only via lecture pip cells.

## The change

One cell, in `lectures/networks.md`:

| Before | After |
|---|---|
| `!pip install quantecon-book-networks==1.6 pandas-datareader` | `!pip install quantecon`<br>`!pip install quantecon-book-networks==1.6`<br>`!pip install pandas-datareader` |

This follows the [code style guide](https://github.com/QuantEcon/QuantEcon.manual/blob/main/manual/styleguide/code.md) — packages outside the Anaconda distribution are installed at the top of the lecture that needs them, in their own standalone `hide-output` cell, one package per `!pip install` line. It also matches [`input_output.md`](https://github.com/QuantEcon/lecture-python-intro/blob/main/lectures/input_output.md), the sibling lecture that uses the same three packages. No prose changes, so there is nothing new for the translation editions to translate.

## The wider check

The issue asked whether any other lecture imports a non-Anaconda package it does not itself install. I audited all 45 lectures — cross-referencing every `import`/`from` statement against the packages named in that lecture's own `!pip install` lines, for `quantecon`, `quantecon_book_networks`, `wbgapi`, `yfinance`, `pandas_datareader`, `plotly`, `xlrd`, `graphviz`, `jax` and `interpolation`. `networks.md` was the only lecture affected, and after this change the audit is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
