### PR TITLE
security: gate the \translate-resync trigger on commenter trust

### DIFF
--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -14,10 +14,21 @@ on:
 
 jobs:
   sync:
+    # The issue_comment path requires all three: a comment on a PR (not a bare
+    # issue), the command, and a trusted author — otherwise any account could
+    # fire a secrets-bearing run (Anthropic spend plus the PAT) from any comment.
     if: >
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '\translate-resync') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
+
+    # The action authenticates with QUANTECON_SERVICES_PAT; the ambient
+    # GITHUB_TOKEN is unused beyond checkout, so keep it read-only.
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Applies the `\translate-resync` trust gate from QuantEcon/action-translation#192 (step 3 of that rollout, tracked in QuantEcon/action-translation#220). No behaviour changes for normal merges.

## Why

The `issue_comment` clause checked only that the comment body contained the magic string. `issue_comment` workflows run in default-branch context with **full access to secrets**, and GitHub cannot filter the event by comment body at the trigger level — so this `if:` is the only gate. On a public repo that means any GitHub account could comment `\translate-resync` on a merged PR and spend Anthropic credits plus runner minutes, repeatedly.

The action already rejects untrusted commenters *internally*, so no translation happens — but the run still starts, checks out, loads the action, and holds `ANTHROPIC_API_KEY` and the services PAT in its environment while doing it. The workflow-level gate is the only thing that stops the job from starting at all.

## What changed

Two edits per file:

1. The `issue_comment` clause now requires the comment to be on a **pull request** (`github.event.issue.pull_request` — plain issues raise the same event, so a comment on any issue used to fire a run too), to carry the command, and to come from an `OWNER`, `MEMBER` or `COLLABORATOR`.
2. A job-level `permissions: contents: read`. The action authenticates to the target repo with `QUANTECON_SERVICES_PAT`; checkout is the ambient `GITHUB_TOKEN`'s only consumer, so it never needs write.

Triggers, `paths:` filters, action inputs and the `@v0` pin are all untouched.

## Who can still trigger a resync

Everyone who could before, in practice: org members and repo collaborators. `CONTRIBUTOR` — anyone with one merged PR — is deliberately excluded, and the action enforces the same three-way set internally, so widening the workflow alone would only produce a billed run that no-ops. The sync bot posts as an org member today, so its comments are unaffected.

## Verification

The folded `if:` is not a theory. This exact shape has been running on QuantEcon/lecture-python.myst since 2026-07-22, and it was E2E-confirmed on the action's test harness on 2026-07-26 across three languages: the merge path fired three green syncs, and a `\translate-resync` comment from a `MEMBER` was admitted by the gate (the job started and logged the resync line). Each file here was also parsed with a YAML parser post-edit to confirm the folded expression is balanced and carries all four conditions.

Worth knowing about the failure mode: a malformed `if:` does not error, it silently stops the workflow firing — which looks exactly like "no PRs have been merged lately". GitHub's workflow linter rejects a malformed `if:` on push, so a clean push is already meaningful evidence; the next merged lecture PR is the real confirmation.

Refs QuantEcon/action-translation#192, QuantEcon/action-translation#220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
