### PR TITLE
CI: gate notebook execution errors on the sphinx-tojupyter step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,13 @@ jobs:
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}
         run: |
-          jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
+          # `shell: bash -l {0}` is a custom shell spec, so GitHub does not inject
+          # `-eo pipefail` (it only does that for the bare `shell: bash` shorthand).
+          # Without this, a failing `jb build` would be masked by the trailing
+          # mkdir/cp, whose exit code becomes the step's — and `--keep-going`
+          # guarantees the .ipynb files exist for `cp` to succeed on.
+          set -eo pipefail
+          jb build lectures -n -W --keep-going --path-output ./ --builder=custom --custom-builder=jupyter
           mkdir -p _build/html/_notebooks
           cp -u _build/jupyter/*.ipynb _build/html/_notebooks
       # Build HTML (Website)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,18 @@ jobs:
       - name: Build PDF from LaTeX
         shell: bash -l {0}
         run: |
-          jb build lectures --builder pdflatex --path-output ./ -n --keep-going
+          # This is the FIRST `jb build` in the workflow, and `execute_notebooks: "cache"`
+          # means only the first build actually executes notebooks — the later
+          # tojupyter and HTML builds read the cache. So this is the step where a
+          # CellExecutionError surfaces, and therefore the step that has to gate.
+          #
+          # `set -eo pipefail` is required as well as `-W`: `shell: bash -l {0}` is a
+          # custom shell spec, so GitHub does not inject `-eo pipefail` (it only does
+          # that for the bare `shell: bash` shorthand). Without it a failing `jb build`
+          # would be masked by the trailing mkdir/cp, whose exit code becomes the
+          # step's — and `--keep-going` guarantees the PDF exists for `cp` to succeed on.
+          set -eo pipefail
+          jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
           mkdir -p _build/html/_pdf
           cp -u _build/latex/*.pdf _build/html/_pdf
       - name: Upload Execution Reports (LaTeX)
@@ -62,13 +73,7 @@ jobs:
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}
         run: |
-          # `shell: bash -l {0}` is a custom shell spec, so GitHub does not inject
-          # `-eo pipefail` (it only does that for the bare `shell: bash` shorthand).
-          # Without this, a failing `jb build` would be masked by the trailing
-          # mkdir/cp, whose exit code becomes the step's — and `--keep-going`
-          # guarantees the .ipynb files exist for `cp` to succeed on.
-          set -eo pipefail
-          jb build lectures -n -W --keep-going --path-output ./ --builder=custom --custom-builder=jupyter
+          jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter
           mkdir -p _build/html/_notebooks
           cp -u _build/jupyter/*.ipynb _build/html/_notebooks
       # Build HTML (Website)


### PR DESCRIPTION
Closes the `lecture-python-intro` half of QuantEcon/meta#340.

## The problem

Two independent defects meant a broken notebook could pass CI green in this repo.

**1. The gate was on no step that could fail.** `lectures/_config.yml` sets `execute_notebooks: "cache"`, so only the **first** `jb build` in the workflow actually executes notebooks — every later builder reads the cache. The first build here is **"Build PDF from LaTeX"**, and it ran with `-n --keep-going` and no `-W`, so a `CellExecutionError` was a non-fatal warning.

**2. That step's exit code was `cp`'s, not `jb build`'s.** It runs three commands under `shell: bash -l {0}`. GitHub only injects `-eo pipefail` for the bare `shell: bash` shorthand; an explicit custom shell spec gets neither `-e` nor `-o pipefail`. So a failing `jb build` was followed by `mkdir` and `cp`, and the step exited with `cp`'s status. `--keep-going` makes this worse rather than better, because it forces Sphinx to emit output despite the errors, guaranteeing the PDF exists for `cp` to succeed on.

Either fix alone is insufficient. Both are applied, to one step.

## The change

`set -eo pipefail` and `-W` on the **"Build PDF from LaTeX"** step — the first `jb build`, and therefore the one that executes. No other step is touched and no `_config.yml` change is needed.

**On why it is this step and not the notebooks step:** the first revision of this PR gated `Build Download Notebooks (sphinx-tojupyter)`, copying the equivalent change already merged in `lecture-python.zh-cn`. That was wrong here. It is correct *there* because that repo's LaTeX step is commented out, which makes tojupyter its first `jb build`. The portable rule is **"gate the first `jb build`"**, not "gate a particular step name" — and which step that is varies across the six repos in QuantEcon/meta#340. Caught by @Copilot's review and by @mmcky.

## Checks done before making the change

- **No `raises-exception` tags** anywhere in `lectures/`, and no intentionally-erroring cells — nothing is relying on an error being tolerated.
- **All 47 published lecture pages** on intro.quantecon.org were scanned for execution-error markers (`output_error`, tracebacks, ANSI red). **Zero hits** — the lectures execute cleanly today.
- `suppress_warnings: [mystnb.unknown_mime_type, myst.domains]` is already configured, so the two known-noisy warning classes will not be promoted by `-W`.

## What CI on this PR is testing

This step has never been able to fail, so this PR is the first real exercise of it. The scan above covers *execution* errors on published content; `-W` also promotes Sphinx **warnings** to errors, and the LaTeX builder emits warnings the HTML builder does not — that class has been invisible here.

If CI goes red, it has found something genuine that was previously silent, and that should be fixed before this merges rather than the flags being softened.

Refs QuantEcon/meta#340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
