### PR TITLE
heavy_tails: cite the Q-Q plot section rather than introduce it cold

### DIFF
--- a/lectures/fitting_distributions.md
+++ b/lectures/fitting_distributions.md
@@ -196,6 +196,7 @@ The other two look plausible.
 To choose between them we need something sharper than a glance at a figure.
 
 
+(qq_plots)=
 ## Q-Q plots
 
 A **Q-Q plot** (short for quantile-quantile plot) compares two distributions by

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -650,11 +650,15 @@ We will use this idea [below](https://intro.quantecon.org/heavy_tails.html#heavy
 
 +++
 
-#### Q-Q Plots
+#### Q-Q plots
 
-We can also use a [qq plot](https://en.wikipedia.org/wiki/Q%E2%80%93Q_plot) to do a visual comparison between two probability distributions. 
+Another visual comparison is provided by the {ref}`Q-Q plot <qq_plots>`, which we introduced in {doc}`fitting_distributions`.
 
-The [statsmodels](https://www.statsmodels.org/stable/index.html) package provides a convenient [qqplot](https://www.statsmodels.org/stable/generated/statsmodels.graphics.gofplots.qqplot.html) function that, by default, compares sample data to the quintiles of the normal distribution.
+There we compared a data set with a distribution fitted to it, and read the departures from the 45 degree line as a diagnosis of how the fit failed.
+
+Here we do the same with the normal distribution as the reference, since our interest is in how far these distributions depart from it.
+
+The [statsmodels](https://www.statsmodels.org/stable/index.html) package provides a convenient [qqplot](https://www.statsmodels.org/stable/generated/statsmodels.graphics.gofplots.qqplot.html) function that, by default, compares sample data with the quantiles of the normal distribution.
 
 If the data is drawn from a normal distribution, the plot would look like:
 


### PR DESCRIPTION
Follow-up to #814.

`heavy_tails` reaches for `sm.qqplot` with only a Wikipedia link by way of explanation, having never said what a Q-Q plot is or how to read one. Now that {doc}`fitting_distributions` defines them — the $i$-th order statistic against the fitted quantile, and what curvature and S-shapes mean — this section can cite that treatment and move straight to the comparison it actually wants.

The `sm.qqplot` calls and both figures are unchanged; only the framing around them.

### Also in this diff

- **A typo in the same paragraph.** It said `statsmodels` compares sample data with "the *quintiles* of the normal distribution". Quantiles.
- **A `(qq_plots)=` label** added to the Q-Q plot section of `fitting_distributions`, so the cross-reference has a target.
- **Heading lower-cased** to "Q-Q plots" per the style guide's rule that only the first word of a non-title heading is capitalized. The anchor is unchanged (`q-q-plots`), and nothing in the series links to it, so no references break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)