### PR TITLE
Link the probability sequence together

### DIFF
--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -153,6 +153,10 @@ Maximum likelihood estimation has two steps:
 2. Estimate the parameter values (e.g., estimate $\mu$ and $\sigma$ for the
    normal distribution)
 
+These are the same two steps discussed in {doc}`fitting_distributions`, which
+chooses parameters by the method of moments instead, and which also shows how
+to judge the resulting fit.
+
 One possible assumption for the wealth is that each
 $w_i$ is [log-normally distributed](https://en.wikipedia.org/wiki/Log-normal_distribution),
 with parameters $\mu \in (-\infty,\infty)$ and $\sigma \in (0,\infty)$.

--- a/lectures/observed_distributions.md
+++ b/lectures/observed_distributions.md
@@ -28,6 +28,9 @@ collect.
 We discuss how to summarize and visualize such data, and how observed data
 connects back to probability distributions.
 
+A third lecture, {doc}`fitting_distributions`, then takes up the question of
+which probability distribution best describes a given data set.
+
 ```{code-cell} ipython3
 :tags: [hide-output]
 
@@ -795,6 +798,9 @@ For example, we might look at the returns from Amazon above and imagine that the
 Here we match a normal distribution to the Amazon monthly returns by setting the
 sample mean to the mean of the normal distribution and the sample variance equal
 to the variance.
+
+(This recipe is called the method of moments, and {doc}`fitting_distributions`
+develops it in full.)
 
 Then we plot the density and the histogram.
 

--- a/lectures/prob_dist.md
+++ b/lectures/prob_dist.md
@@ -22,9 +22,14 @@ In data science applications, we are often interested in data on a specific vari
 
 In this lecture we give a quick introduction to probability distributions using Python.
 
-A companion lecture, {doc}`observed_distributions`, treats observed data --- sets
-of numbers that we measure or collect --- and its connection to the probability
+This lecture is the first of three.
+
+The second, {doc}`observed_distributions`, treats observed data --- sets of
+numbers that we measure or collect --- and its connection to the probability
 distributions studied here.
+
+The third, {doc}`fitting_distributions`, asks which probability distribution
+best describes a given data set.
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt


### PR DESCRIPTION
`fitting_distributions` (#814) was reachable only from the table of contents and from `heavy_tails`. Neither of the two lectures it builds on mentioned it, so a reader working through the sequence in order had no pointer forward.

### Before / after

| lecture | linked to, before | after |
| --- | --- | --- |
| `prob_dist` | observed_distributions, heavy_tails | **+ fitting_distributions** |
| `observed_distributions` | prob_dist, heavy_tails | **+ fitting_distributions** |
| `mle` | *nothing* | **fitting_distributions** |

### The three edits

- **`prob_dist`** now introduces itself as the first of three and names both of the others, replacing a sentence that named only `observed_distributions`.
- **`observed_distributions`** points forward in its outline, and again at the place where it fits a normal to the Amazon returns by matching sample moments to population moments. That *is* the method of moments — unnamed there, and the subject of the next lecture — so the pointer sits exactly where the reader meets the idea for the first time.
- **`mle`** gains its first cross-reference to any other lecture. Its two steps for maximum likelihood — guess the distribution, then estimate the parameters — are precisely the two questions `fitting_distributions` is organized around, so it now says so. This closes a loop: `fitting_distributions` already sends readers to `mle` twice, once for a fuller treatment of parameter estimation and once for the Student *t* fit that the method of moments handles poorly.

Prose only; both executable lectures still run end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)