### PR TITLE
french_rev: read the five datasets from data-lectures

### DIFF
--- a/lectures/french_rev.md
+++ b/lectures/french_rev.md
@@ -57,18 +57,20 @@ We use matplotlib to replicate several of the graphs with which  {cite}`sargent_
 ## Data Sources
 
 This lecture uses data from three spreadsheets assembled by {cite}`sargent_velde1995`:
-  * [datasets/fig_3.xlsx](https://github.com/QuantEcon/lecture-python-intro/blob/main/lectures/datasets/fig_3.xlsx)
-  * [datasets/dette.xlsx](https://github.com/QuantEcon/lecture-python-intro/blob/main/lectures/datasets/dette.xlsx)
-  * [datasets/assignat.xlsx](https://github.com/QuantEcon/lecture-python-intro/blob/main/lectures/datasets/assignat.xlsx)
+  * [fig_3.xlsx](https://github.com/QuantEcon/data-lectures/blob/main/lectures/fig_3.xlsx)
+  * [dette.xlsx](https://github.com/QuantEcon/data-lectures/blob/main/lectures/dette.xlsx)
+  * [assignat.xlsx](https://github.com/QuantEcon/data-lectures/blob/main/lectures/assignat.xlsx)
 
 ```{code-cell} ipython3
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+from io import BytesIO
+import requests
 plt.rcParams.update({'font.size': 12})
 
-base_url = 'https://github.com/QuantEcon/lecture-python-intro/raw/'\
-           + 'main/lectures/datasets/'
+base_url = 'https://github.com/QuantEcon/data-lectures/raw/'\
+           + 'main/lectures/'
 
 fig_3_url = f'{base_url}fig_3.xlsx'
 dette_url = f'{base_url}dette.xlsx'
@@ -706,8 +708,10 @@ def fit(x, y):
 
 ```{code-cell} ipython3
 # Load data
-caron = np.load('datasets/caron.npy')
-nom_balances = np.load('datasets/nom_balances.npy')
+caron_response = requests.get(f'{base_url}caron.npy')
+nom_balances_response = requests.get(f'{base_url}nom_balances.npy')
+caron = np.load(BytesIO(caron_response.content))
+nom_balances = np.load(BytesIO(nom_balances_response.content))
 
 infl = np.concatenate(([np.nan],
       -np.log(caron[1:63, 1] / caron[0:62, 1])))


### PR DESCRIPTION
Repoints all five `french_rev` datasets onto QuantEcon/data-lectures, completing the intro static batch. Part of QuantEcon/workspace-lectures#23 (step 2); data-side record in QuantEcon/data-lectures#49.

## What changes

`assignat.xlsx`, `dette.xlsx` and `fig_3.xlsx` move together, since the lecture builds all three URLs from one `base_url` f-string. `caron.npy` and `nom_balances.npy` change individually — and they are the substantive fix in this PR.

Those two were **local-path reads**: `np.load('datasets/caron.npy')` resolves only when the process happens to be running with `lectures/` as its working directory. In the notebook a reader downloads from `intro.quantecon.org`, or opens in Colab, it raised `FileNotFoundError`. They now fetch over HTTP and load through `BytesIO`, which is the idiom `lecture-wasm` has always used for these two files. **These were the last local-path data reads in this repo** — the failure mode P1 was created to fix.

The three markdown links under **Data Sources** are repointed too. They are prose, so no build checks them, and they would have 404'd once this repo's copies are deleted. They are two of the references inventoried in QuantEcon/data-lectures#42.

## Verification

Every file served from data-lectures was fetched and compared against the copy this lecture read before:

| Dataset | Served | sha256 vs old copy | vs manifest |
| --- | --- | --- | --- |
| `assignat.xlsx` | 200, 209,555 B | identical | matches |
| `dette.xlsx` | 200, 632,030 B | identical | matches |
| `fig_3.xlsx` | 200, 9,466 B | identical | matches |
| `caron.npy` | 200, 1,136 B | identical | matches |
| `nom_balances.npy` | 200, 1,424 B | identical | matches |

Both `.npy` files additionally load to arrays equal to the previous local `np.load`, with identical shape and dtype (`(63, 2)` and `(81, 2)`, `float64`). All three repointed prose links return 200.

Byte-identity is what makes this provably unable to change a figure: the three workbooks are `positional_reads: true`, read by cell position with `usecols`/`skiprows`/`nrows`, so identical bytes are the only guarantee that matters.

## Sequencing

This repo's copies under `lectures/datasets/` are **deliberately kept here** and deleted in a follow-up once the site is published, per repoint rule 3 — the published notebook lags `main`, and deleting in this PR would 404 the downloadable notebook and its Colab link until a `publish*` tag is cut.

Pairs with QuantEcon/lecture-wasm#55, which must land in the same set (repoint rule 2) — wasm fetches this repo's committed blobs by URL, and data-lectures' strict audit has no green state while only one side has moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)