### PR TITLE
CI: guard against reading data-lectures over the LFS media host

### DIFF
--- a/.github/workflows/data-url-guard.yml
+++ b/.github/workflows/data-url-guard.yml
@@ -1,0 +1,36 @@
+# A dataset read that points at the wrong host fails in the reader's notebook,
+# not in CI. The data-audit dashboard that would catch it lives in
+# QuantEcon/data-lectures, runs on that repo's pushes and a weekly cron, and
+# never on a pull request here — so its detection lag is up to seven days.
+# This is the only check that fires at the moment of the change.
+#
+# See QuantEcon/data-lectures PLAN.md, repoint rule 6.
+
+name: Data URL guard
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  data-url-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: No data-lectures read on the LFS media host
+        run: |
+          # media.githubusercontent.com is the LFS *media* endpoint and routes
+          # per path: it serves a file only where that path is LFS-tracked in
+          # the repo the URL names, and 404s otherwise. Everything data-lectures
+          # publishes is plain git, so this host never resolves for it — and a
+          # mechanical org/repo swap that preserves the host breaks every read.
+          #
+          # grep -r walks lectures/_static/**/*.ipynb, which the data-lectures
+          # audit deliberately does not scan and this repo's build never
+          # executes (lectures/_config.yml, exclude_patterns).
+          if grep -rnF 'media.githubusercontent.com/media/QuantEcon/data-lectures' lectures/; then
+            echo "::error::Read data-lectures over raw.githubusercontent.com (or the github.com/.../raw/ redirect), never media.githubusercontent.com — that host is LFS-only and 404s every file data-lectures publishes."
+            exit 1
+          fi
+          echo "OK — no data-lectures read on the media host."


### PR DESCRIPTION
Gate 2 of QuantEcon/workspace-lectures#23 step 3. One new workflow, no lecture changes.

## The failure it catches

`media.githubusercontent.com` is the LFS **media** endpoint. It routes **per path**, not per repo — it serves a file only where that path is LFS-tracked in the repo the URL names, and 404s otherwise. Everything `QuantEcon/data-lectures` publishes is plain git, so that host never resolves for it:

| URL | Result |
| --- | --- |
| `raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/mpd2020.xlsx` | **200** |
| `media.githubusercontent.com/media/QuantEcon/data-lectures/main/lectures/mpd2020.xlsx` | **404** |

Both hosts send `access-control-allow-origin: *`, so this is host routing, not CORS — a different failure from repoint rule 5, and unlike rule 5 it hits CPython consumers too.

This matters right now because the six `high_dim_data` datasets are LFS-tracked *there*, so this repo reads them from the media host today. When they land in data-lectures as plain git, **a mechanical org/repo swap that preserves the host breaks every one of them.**

## Why here, and why a separate workflow

The check that would otherwise catch it is the data-audit dashboard in `QuantEcon/data-lectures` — but that workflow triggers on pushes to *that* repo, a weekly Monday cron, and PRs touching *its* paths. No event in this repo reaches it, so its detection lag after a bad repoint merges is up to seven days. This runs pre-merge, in the repo being changed.

`grep -r` over `lectures/` also walks `lectures/_static/**/*.ipynb`. That matters: the audit deliberately excludes `_static/` from its scan, and `lectures/_config.yml` excludes it from execution, so `_static/lecture_specific/inequality/data.ipynb` is invisible to every other mechanism. This guard is the only thing that sees it.

## Scope and honesty about what it is

It **matches zero lines today** — verified, `grep` exits 1 in a clean tree — so it goes green on merge and is armed before the fold rather than landing alongside it.

It is a literal host-string check. It cannot see a wrong ref, a preserved source subdirectory, or a repoint that lands before the bytes do; those are asserted post-merge by the strict audit in QuantEcon/data-lectures#55. The two are complements.

And it is an alarm, not a gate: `main`'s `required_status_checks` has `contexts: []`, so this will show as a failed check on the PR without blocking the merge. Adding it as a required context is a separate, deliberate decision.

The companion assertion — that no `high_dim_data` URL remains anywhere — matches 7 lines here today, so it belongs in the repoint PR itself, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)