### PR TITLE
CI: least-privilege token for the data URL guard

### DIFF
--- a/.github/workflows/data-url-guard.yml
+++ b/.github/workflows/data-url-guard.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     # This job greps a checkout and writes nothing. The repo default is
     # `write`, so without this it would receive a token that can also approve
-    # pull requests.
+    # pull request reviews.
     permissions:
       contents: read
     steps:

--- a/.github/workflows/data-url-guard.yml
+++ b/.github/workflows/data-url-guard.yml
@@ -16,6 +16,11 @@ on:
 jobs:
   data-url-guard:
     runs-on: ubuntu-latest
+    # This job greps a checkout and writes nothing. The repo default is
+    # `write`, so without this it would receive a token that can also approve
+    # pull requests.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - name: No data-lectures read on the LFS media host


### PR DESCRIPTION
Follow-up to QuantEcon/lecture-python-intro#830. One line plus a comment.

The `data-url-guard` job greps a checkout and writes nothing, but this repository's `default_workflow_permissions` is `write` with `can_approve_pull_request_reviews: true` — so as merged, the job receives a token that can push to the repo and approve pull requests. Adding an explicit `permissions: contents: read` block scopes it to what it actually needs.

Raised by Copilot on the wasm twin, QuantEcon/lecture-wasm#58, which carries the same change. Copilot left no inline comments on #830, so it landed here unflagged.

Scoped deliberately to this workflow. `cache.yml`, `ci.yml` and `collab.yml` have the same gap and are untouched here; `linkcheck.yml`, `publish.yml` and `sync-translations-zh-cn.yml` already scope theirs. A repo-wide pass is a separate question.

The error-message rewording in the wasm PR is **not** mirrored here: intro's message carries a `never media.githubusercontent.com` clause that forces the imperative reading, and wasm's drops it because repoint rule 5 bars the `github.com/*/raw/` form for code cells that execute in the reader's browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)