### PR TITLE
Read the six folded datasets from data-lectures, not high_dim_data

### DIFF
--- a/lectures/_static/lecture_specific/inequality/data.ipynb
+++ b/lectures/_static/lecture_specific/inequality/data.ipynb
@@ -34,7 +34,7 @@
     "import wbgapi as wb\n",
     "import plotly.express as px\n",
     "\n",
-    "url = 'https://media.githubusercontent.com/media/QuantEcon/high_dim_data/main/SCF_plus/SCF_plus_mini.csv'\n",
+    "url = 'https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/SCF_plus_mini.csv'\n",
     "df = pd.read_csv(url)\n",
     "df_income_wealth = df.dropna()"
    ]

--- a/lectures/heavy_tails.md
+++ b/lectures/heavy_tails.md
@@ -824,7 +824,7 @@ mystnb:
     name: firm-size-dist
 tags: [hide-input]
 ---
-df_fs = pd.read_csv('https://media.githubusercontent.com/media/QuantEcon/high_dim_data/main/cross_section/forbes-global2000.csv')
+df_fs = pd.read_csv('https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/forbes-global2000.csv')
 df_fs = df_fs[['Country', 'Sales', 'Profits', 'Assets', 'Market Value']]
 fig, ax = plt.subplots(figsize=(6.4, 3.5))
 
@@ -851,8 +851,8 @@ mystnb:
 tags: [hide-input]
 ---
 # import population data of cities in 2023 United States and 2023 Brazil from world population review
-df_cs_us = pd.read_csv('https://media.githubusercontent.com/media/QuantEcon/high_dim_data/main/cross_section/cities_us.csv')
-df_cs_br = pd.read_csv('https://media.githubusercontent.com/media/QuantEcon/high_dim_data/main/cross_section/cities_brazil.csv')
+df_cs_us = pd.read_csv('https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/cities_us.csv')
+df_cs_br = pd.read_csv('https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/cities_brazil.csv')
 
 fig, axes = plt.subplots(1, 2, figsize=(8.8, 3.6))
 
@@ -876,7 +876,7 @@ mystnb:
     name: wealth-dist
 tags: [hide-input]
 ---
-df_w = pd.read_csv('https://media.githubusercontent.com/media/QuantEcon/high_dim_data/main/cross_section/forbes-billionaires.csv')
+df_w = pd.read_csv('https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/forbes-billionaires.csv')
 df_w = df_w[['country', 'realTimeWorth', 'realTimeRank']].dropna()
 df_w = df_w.astype({'realTimeRank': int})
 df_w = df_w.sort_values('realTimeRank', ascending=True).copy()

--- a/lectures/inequality.md
+++ b/lectures/inequality.md
@@ -246,7 +246,7 @@ The following code block imports a subset of the dataset `SCF_plus` for 2016,
 which is derived from the [Survey of Consumer Finances](https://en.wikipedia.org/wiki/Survey_of_Consumer_Finances) (SCF).
 
 ```{code-cell} ipython3
-url = 'https://github.com/QuantEcon/high_dim_data/raw/main/SCF_plus/SCF_plus_mini.csv'
+url = 'https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/SCF_plus_mini.csv'
 df = pd.read_csv(url)
 df_income_wealth = df.dropna()
 ```

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -90,7 +90,7 @@ The following code imports this data  and reads it into an array called `sample`
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-url = 'https://github.com/QuantEcon/high_dim_data/raw/main/SCF_plus/SCF_plus_mini_no_weights.csv'
+url = 'https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/SCF_plus_mini_no_weights.csv'
 df = pd.read_csv(url)
 df = df.dropna()
 df = df[df['year'] == 2016]


### PR DESCRIPTION
Seven reads across four files. The six datasets moved into `QuantEcon/data-lectures` (QuantEcon/data-lectures#62), so every read here follows them — and the **host** changes too, not just the org and repo.

## Why the host has to change

`media.githubusercontent.com` is the LFS **media** endpoint and routes **per path** by LFS status. These six were LFS-tracked in `high_dim_data` and are **plain git** in `data-lectures`, so the media host 404s for every one of them. Measured today:

| URL | |
| --- | --- |
| `media.githubusercontent.com/media/QuantEcon/data-lectures/main/lectures/SCF_plus_mini.csv` | **404**, 0 bytes |
| `raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/SCF_plus_mini.csv` | **200**, 6,118,055 B gzipped |

A mechanical org/repo swap that preserved the host would have broken every chart in these three lectures. This is repoint rule 6.

## Why everything lands on `raw.githubusercontent.com`

All four consuming repos now spell these reads identically. The set 1/2 repoints broke `lecture-wasm` by "harmonising" its URLs **onto** the `github.com/…/raw/` redirect form (QuantEcon/data-lectures#46) — reasonable-looking, since the two spellings did look like an inconsistency, but that form's 302 carries an **empty** `access-control-allow-origin`, so a browser rejects it before following the redirect. One spelling on these lines means that class of fix cannot recur.

This does leave `lecture-python-intro` carrying two spellings across *different* lectures — sets 1–3 are on the `github.com` form, the fold is on raw. Accepted as short-term: both resolve, both pass the audit, and `qeld` (QuantEcon/data-lectures#65, tracker QuantEcon/data-lectures#66) is intended to resolve dataset URLs through one call site and make the spelling an implementation detail. The bar here is that each link works in the context it is in.

## The notebook is the read nothing would carry

`_static/lecture_specific/inequality/data.ipynb:37` is edited by hand. No audit scans `_static/**`, the build never executes it, and the translation sync is `.md`-only — so nothing mechanical would ever surface or carry this change. It is also a **served artifact**: it returns 200 on the published site with the URL in its body, so leaving it stale keeps serving a dead link to anyone who downloads it.

## No prose is touched

The lecture says the Forbes billionaires data is a 2020 snapshot. The bytes contradict it — 2,935 rows, **282 distinct timestamps spanning 2020-04-07 to 2023-04-15**, and the chart plots `realTimeWorth`/`realTimeRank` rather than the annual list's `worth`/`rank`. That is content rather than a repoint, so it is split out to QuantEcon/workspace-lectures#35. The **Global 2000 "2020" claim nearby is correct** — its builder hardcodes the 2020 endpoint — and is deliberately left alone; the two claims look alike and sit close together.

## Verification

- **Both acceptance greps clean**: no media-host `data-lectures` read, and **no `high_dim_data` reference anywhere** in `lectures/`
- **All 7 URLs return 200**
- **Three-way byte identity** on the four `cross_section` files — manifest `sha256` = new URL = old `high_dim_data` URL, so this changes the address and not the data. The SCF pair was verified against `high_dim_data`'s LFS objects in QuantEcon/data-lectures#62

## This repo specifically

`data-url-guard` fires on this PR and greps all of `lectures/`, `_static` notebooks included — so the notebook edit above is covered here, unlike in the two repos with no CI. This repo's CI also **executes** the cells, so a dead URL raises `CellExecutionError` rather than passing quietly. Note `main` has `required_status_checks` with empty `contexts`, so that red would be loud but not blocking.

Part of QuantEcon/workspace-lectures#23 (step 3, PR set C2). Companion PRs land in `lecture-wasm` and `test-actions-lecture-intro` under the same title. **Merged as three independent branches off `main`, never stacked.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)