### PR TITLE
Read life-expectancy and usa-gini from data-lectures

### DIFF
--- a/lectures/inequality.md
+++ b/lectures/inequality.md
@@ -618,7 +618,7 @@ df_income_wealth.year.describe()
 [This notebook](https://github.com/QuantEcon/lecture-python-intro/tree/main/lectures/_static/lecture_specific/inequality/data.ipynb) can be used to compute this information over the full dataset.
 
 ```{code-cell} ipython3
-data_url = 'https://github.com/QuantEcon/lecture-python-intro/raw/main/lectures/_static/lecture_specific/inequality/usa-gini-nwealth-tincome-lincome.csv'
+data_url = 'https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/usa-gini-nwealth-tincome-lincome.csv'
 ginis = pd.read_csv(data_url, index_col='year')
 ginis.head(n=5)
 ```

--- a/lectures/simple_linear_regression.md
+++ b/lectures/simple_linear_regression.md
@@ -408,12 +408,12 @@ Let's consider two economic variables GDP per capita and Life Expectancy.
 <iframe src="https://ourworldindata.org/grapher/life-expectancy-vs-gdp-per-capita" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>
 :::
 
-You can download {download}`a copy of the data here <https://github.com/QuantEcon/lecture-python-intro/raw/main/lectures/_static/lecture_specific/simple_linear_regression/life-expectancy-vs-gdp-per-capita.csv>` if you get stuck
+You can download {download}`a copy of the data here <https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/life-expectancy-vs-gdp-per-capita.csv>` if you get stuck
 
 **Q3:** Use `pandas` to import the `csv` formatted data and plot a few different countries of interest
 
 ```{code-cell} ipython3
-data_url = "https://github.com/QuantEcon/lecture-python-intro/raw/main/lectures/_static/lecture_specific/simple_linear_regression/life-expectancy-vs-gdp-per-capita.csv"
+data_url = "https://raw.githubusercontent.com/QuantEcon/data-lectures/main/lectures/life-expectancy-vs-gdp-per-capita.csv"
 df = pd.read_csv(data_url, nrows=10)
 ```
 


### PR DESCRIPTION
Wave A4 of the datasets migration. The last two Track A CSVs moved to `QuantEcon/data-lectures` in QuantEcon/data-lectures#74, which is merged and serving both files. **Three URLs.**

All three land on `raw.githubusercontent.com` — one spelling for reads and `{download}` roles alike, matching the decision taken during the `high_dim_data` fold. It drops a redirect hop and avoids the two-hosts-in-one-file split that the "harmonise these forms" class of fix has broken before. This does differ from the older `github.com/…/raw/` form used by earlier repoint sets; harmonising those is a separate sweep, deliberately not this PR.

## Left alone on purpose

**`simple_linear_regression.md` — `cols = ['Code', 'Year', 'Life expectancy at birth (historical)', 'GDP per capita']`.** The migrated bytes are byte-identical to intro's, so the old column label is still the correct one. Upstream OWID has since renamed four of eight columns, moved the annotations column, and halved the row count; that delta is recorded in the new manifest and registered on QuantEcon/data-lectures#39. Adopting it would change every life-expectancy value while leaving the 2018 scatter looking identical — a content change with re-reviewed figures, not a repoint.

**`inequality.md` — the `[This notebook]` link** to intro's `_static/lecture_specific/inequality/data.ipynb`. It points at a notebook, not a dataset, and that notebook stays in `lecture-python-intro`.

## Verification

Line numbers re-derived immediately before editing, not carried from a table. Both targets serve `HTTP 200` with `access-control-allow-origin: *`, and their sha256 match the manifests exactly (`ec5d3235…`, `bed9074a…`).

**Old and new URLs produce identical frames under the lecture's own code** — stronger than checking the URL returns 200:

| Read | Old → New |
| --- | --- |
| `read_csv(data_url, nrows=10)` | (10, 8) vs (10, 8), `equals: True` |
| `read_csv(data_url, usecols=cols)` | (62156, 4) vs (62156, 4), `equals: True` |
| …then `.dropna()` | 12,445 vs 12,445 — which is what the prose asserts |
| …then `Year == 2018` (the fitted scatter) | 166 vs 166 rows, `equals: True` |
| `read_csv(data_url, index_col='year')` | (20, 3) vs (20, 3), identical index |

So this provably cannot change a figure.

Also checked: the commit carries **both** the added and removed URL lines in each file (a scripted repoint has silently shipped deletions-without-URL-change before), and no reference to intro's copies of either file remains.

## This repo keeps its committed copies

Deleting them is **phase 2** and is gated on more than this merge. `publish.yml` here fires on a `publish*` tag, so merging does not refresh the published notebooks — and `lecture-intro.zh-cn` and `test-actions-lecture-intro` are tag-gated too. Their published sites currently reference these exact paths. Deleting before all of those republish is precisely what QuantEcon/workspace-lectures#28 recorded.

CI here is the real check for this set: intro executes both lectures, so a dead URL raises `CellExecutionError`. (Its `main` has `required_status_checks` with empty `contexts`, so that red is loud but not a merge gate.)

## Merge together with

QuantEcon/lecture-wasm and QuantEcon/test-actions-lecture-intro, same branch name. Repoint rule 2 — the strict audit has no green state for a partially-repointed dataset, and merging one half while the other sits open reproduces the 2026-08-06 failure. QuantEcon/lecture-intro.zh-cn#294 is already merged ahead of this, so the sync PR this generates should be a no-op on the repointed lines. **Hand-diff that sync PR anyway.**

Tracking: QuantEcon/workspace-lectures#23